### PR TITLE
[SC-40] end user needs access to provision products

### DIFF
--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -17,7 +17,6 @@ Resources:
         - arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess
         - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
         - !Ref SCEnduserExpandedPolicy
-        - !Ref CFNDenyGetTemplateSummaryPolicy
       Path: /
   SCEnduserRole:
     Type: AWS::IAM::Role
@@ -26,7 +25,6 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
         - !Ref SCEnduserExpandedPolicy
-        - !Ref CFNDenyGetTemplateSummaryPolicy
       Path: /
       AssumeRolePolicyDocument:
         Version: 2012-10-17


### PR DESCRIPTION
We added deny GetTemplateSummary policy to restrict access to secrets however this also blocks provisioning of products.  Remove this policy to unblock provisioning.