### PR TITLE
[SC-128] export the portfolio id

### DIFF
--- a/s3/sc-portfolio-s3-basic.yaml
+++ b/s3/sc-portfolio-s3-basic.yaml
@@ -155,3 +155,9 @@ Resources:
         StackDatetime: !Ref StackDatetime
       TemplateURL: !Sub '${RepoRootURL}s3/sc-product-s3-synapse.yaml'
       TimeoutInMinutes: 5
+
+Outputs:
+  SCS3portfolioId:
+    Value: !Ref SCS3portfolio
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SCS3portfolioId'


### PR DESCRIPTION
We export the portfolio ID so we can import into a downstream
template.