### PR TITLE
Specify AWS Region

### DIFF
--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -60,7 +60,7 @@ Resources:
           - Effect: Allow
             Action:
               - ssm:StartSession
-            Resource: !Sub "arn:aws:ec2::${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
             Condition:
               StringLike:
                 "ssm:ResourceTag/AccessApprovedCaller": "${aws:userid}"


### PR DESCRIPTION
It turns out we need to specify the region explicitly in order to match permissions between the principal and resource, which makes sense because otherwise it would be inadvertently excessive.