### PR TITLE
[SC-111] Refactor portfolio template

### DIFF
--- a/ec2/sc-portfolio-ec2.yaml
+++ b/ec2/sc-portfolio-ec2.yaml
@@ -1,26 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: EC2 Portfolio for Service Catalog. (fdp-1p4da46nc)
-Metadata:
-  AWS::CloudFormation::Interface:
-    ParameterGroups:
-      - Label:
-          default: Portfolio Information
-        Parameters:
-          - PorfolioName
-          - PortfolioProvider
-          - PorfolioDescription
-      - Label:
-          default: IAM Settings
-        Parameters:
-          - LaunchRoleName
-          - PrincipalRoleName1
-          - PrincipalGroupName1
-          - PrincipalRoleName2
-          - PrincipalGroupName2
-      - Label:
-          default: Product Settings
-        Parameters:
-          - RepoRootURL
 Parameters:
   PortfolioProvider:
     Type: String
@@ -35,29 +14,6 @@ Parameters:
     Description: Portfolio Description
     Default: Service Catalog Portfolio that contains reference architecture products
       for Amazon Elastic Compute Cloud (EC2).
-  LaunchRoleName:
-    Type: String
-    Description: Name of the launch constraint role for EC2 products. leave this blank
-      to create the role.
-  PrincipalRoleName1:
-    Type: String
-    Description: Name of an IAM role which can execute products
-      in this portfolio.
-  PrincipalGroupName1:
-    Type: String
-    Description: (Optional) Name of an IAM  group which can execute products
-      in this portfolio.
-    Default: ''
-  PrincipalRoleName2:
-    Type: String
-    Description: (Optional) Name of an IAM role which can execute products
-      in this portfolio.
-    Default: ''
-  PrincipalGroupName2:
-    Type: String
-    Description: (Optional) Name of an IAM  group which can execute products
-      in this portfolio.
-    Default: ''
   RepoRootURL:
     Type: String
     Description: S3 root url for the repository containing the product templates.
@@ -66,26 +22,6 @@ Parameters:
     Type: String
     Description: Last updated date and time of portfolio
     Default: ''
-Conditions:
-  CreateLaunchConstraint: !Equals
-    - !Ref 'LaunchRoleName'
-    - ''
-  CondPrincipalRoleName1: !Not
-    - !Equals
-      - !Ref 'PrincipalRoleName1'
-      - ''
-  CondPrincipalGroupName1: !Not
-    - !Equals
-      - !Ref 'PrincipalGroupName1'
-      - ''
-  CondPrincipalRoleName2: !Not
-    - !Equals
-      - !Ref 'PrincipalRoleName2'
-      - ''
-  CondPrincipalGroupName2: !Not
-    - !Equals
-      - !Ref 'PrincipalGroupName2'
-      - ''
 Resources:
   SCEC2portfolio:
     Type: AWS::ServiceCatalog::Portfolio
@@ -93,38 +29,18 @@ Resources:
       ProviderName: !Ref 'PortfolioProvider'
       Description: !Ref 'PorfolioDescription'
       DisplayName: !Ref 'PorfolioName'
-  LaunchConstraintRole:
-    Type: AWS::CloudFormation::Stack
-    Condition: CreateLaunchConstraint
-    Properties:
-      TemplateURL: !Sub '${RepoRootURL}iam/sc-ec2vpc-launchrole.yaml'
-      TimeoutInMinutes: 5
   LinkEndusersRole:
     Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
-    Condition: CondPrincipalRoleName1
     Properties:
-      PrincipalARN: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${PrincipalRoleName1}'
+      PrincipalARN: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-RoleArn'
       PortfolioId: !Ref 'SCEC2portfolio'
       PrincipalType: IAM
   LinkEndusersGroup:
     Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
-    Condition: CondPrincipalGroupName1
     Properties:
       PrincipalARN: !Sub 'arn:aws:iam::${AWS::AccountId}:group/${PrincipalGroupName1}'
-      PortfolioId: !Ref 'SCEC2portfolio'
-      PrincipalType: IAM
-  LinkEndusersAltRole:
-    Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
-    Condition: CondPrincipalRoleName2
-    Properties:
-      PrincipalARN: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${PrincipalRoleName2}'
-      PortfolioId: !Ref 'SCEC2portfolio'
-      PrincipalType: IAM
-  LinkEndusersAltGroup:
-    Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
-    Condition: CondPrincipalGroupName2
-    Properties:
-      PrincipalARN: !Sub 'arn:aws:iam::${AWS::AccountId}:group/${PrincipalGroupName2}'
+        'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-GroupArn'
       PortfolioId: !Ref 'SCEC2portfolio'
       PrincipalType: IAM
   Ec2LinuxJumpcloudProduct:
@@ -132,10 +48,8 @@ Resources:
     Properties:
       Parameters:
         PortfolioProvider: !Ref 'PortfolioProvider'
-        LaunchConstraintARN: !If
-          - CreateLaunchConstraint
-          - !GetAtt 'LaunchConstraintRole.Outputs.LaunchRoleArn'
-          - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
+        LaunchConstraintARN: !ImportValue
+          'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
         StackDatetime: !Ref StackDatetime
@@ -146,10 +60,8 @@ Resources:
     Properties:
       Parameters:
         PortfolioProvider: !Ref 'PortfolioProvider'
-        LaunchConstraintARN: !If
-          - CreateLaunchConstraint
-          - !GetAtt 'LaunchConstraintRole.Outputs.LaunchRoleArn'
-          - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
+        LaunchConstraintARN: !ImportValue
+          'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
         StackDatetime: !Ref StackDatetime
@@ -160,10 +72,8 @@ Resources:
     Properties:
       Parameters:
         PortfolioProvider: !Ref 'PortfolioProvider'
-        LaunchConstraintARN: !If
-          - CreateLaunchConstraint
-          - !GetAtt 'LaunchConstraintRole.Outputs.LaunchRoleArn'
-          - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
+        LaunchConstraintARN: !ImportValue
+          'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
         StackDatetime: !Ref StackDatetime
@@ -174,30 +84,30 @@ Resources:
     Properties:
       Parameters:
         PortfolioProvider: !Ref 'PortfolioProvider'
-        LaunchConstraintARN: !If
-          - CreateLaunchConstraint
-          - !GetAtt 'LaunchConstraintRole.Outputs.LaunchRoleArn'
-          - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
+        LaunchConstraintARN: !ImportValue
+          'Fn::Sub': '${AWS::Region}-sc-ec2vpc-launchrole-LaunchRoleArn'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
         StackDatetime: !Ref StackDatetime
       TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-windows-jumpcloud.yaml'
       TimeoutInMinutes: 5
 Outputs:
-  LaunchConstraintRoleARN:
-    Condition: CreateLaunchConstraint
-    Value: !GetAtt 'LaunchConstraintRole.Outputs.LaunchRoleArn'
-  LaunchConstraintRoleName:
-    Condition: CreateLaunchConstraint
-    Value: !GetAtt 'LaunchConstraintRole.Outputs.LaunchRoleName'
   Ec2LinuxJumpcloudProductId:
     Value: !GetAtt 'Ec2LinuxJumpcloudProduct.Outputs.ProductId'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2LinuxJumpcloudProductId'
   Ec2LinuxJumpcloudNotebookProductId:
     Value: !GetAtt 'Ec2LinuxJumpcloudNotebookProduct.Outputs.ProductId'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2LinuxJumpcloudNotebookProductId'
   Ec2LinuxJumpcloudWorkflowsProductId:
     Value: !GetAtt 'Ec2LinuxJumpcloudWorkflowsProduct.Outputs.ProductId'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2LinuxJumpcloudWorkflowsProductId'
   Ec2WindowsJumpcloudProductId:
     Value: !GetAtt 'Ec2WindowsJumpcloudProduct.Outputs.ProductId'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2WindowsJumpcloudProductId'
   SCEC2portfolioId:
     Value: !Ref SCEC2portfolio
     Export:


### PR DESCRIPTION
Refactor to use cross stack imports intead of passing in parameters.
We also removed unnessary paramters and make it more conducive for
sceptre deployment.

The main idea here is to make the template easier to understand for
preparation to remove 'AWS::CloudFormation::Stack' from this template