### PR TITLE
[SC-111] Refactor S3 portfolio template

### DIFF
--- a/s3/sc-portfolio-s3-basic.yaml
+++ b/s3/sc-portfolio-s3-basic.yaml
@@ -1,26 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: S3 Portfolio for Service Catalog. (fdp-1p5rtpgl6)
-Metadata:
-  AWS::CloudFormation::Interface:
-    ParameterGroups:
-      - Label:
-          default: Portfolio Information
-        Parameters:
-          - PorfolioName
-          - PortfolioProvider
-          - PorfolioDescription
-      - Label:
-          default: IAM Settings
-        Parameters:
-          - LaunchRoleName
-          - PrincipalRoleName1
-          - PrincipalGroupName1
-          - PrincipalRoleName2
-          - PrincipalGroupName2
-      - Label:
-          default: Product Settings
-        Parameters:
-          - RepoRootURL
 Parameters:
   PortfolioProvider:
     Type: String
@@ -35,29 +14,6 @@ Parameters:
     Description: Portfolio Description
     Default: Service Catalog Portfolio that contains reference architecture products
       for Amazon Simple Storage Service.
-  LaunchRoleName:
-    Type: String
-    Description: Name of the launch constraint role for VPC products. leave this blank
-      to create the role.
-  PrincipalRoleName1:
-    Type: String
-    Description: Name of an IAM role which can execute products
-      in this portfolio.
-  PrincipalGroupName1:
-    Type: String
-    Description: (Optional) Name of an IAM  group which can execute products
-      in this portfolio.
-    Default: ''
-  PrincipalRoleName2:
-    Type: String
-    Description: (Optional) Name of an IAM role which can execute products
-      in this portfolio.
-    Default: ''
-  PrincipalGroupName2:
-    Type: String
-    Description: (Optional) Name of an IAM  group which can execute products
-      in this portfolio.
-    Default: ''
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
@@ -66,26 +22,6 @@ Parameters:
     Type: String
     Description: Last updated date and time of portfolio
     Default: ''
-Conditions:
-  CreateLaunchConstraint: !Equals
-    - !Ref 'LaunchRoleName'
-    - ''
-  CondPrincipalRoleName1: !Not
-    - !Equals
-      - !Ref 'PrincipalRoleName1'
-      - ''
-  CondPrincipalGroupName1: !Not
-    - !Equals
-      - !Ref 'PrincipalGroupName1'
-      - ''
-  CondPrincipalRoleName2: !Not
-    - !Equals
-      - !Ref 'PrincipalRoleName2'
-      - ''
-  CondPrincipalGroupName2: !Not
-    - !Equals
-      - !Ref 'PrincipalGroupName2'
-      - ''
 Resources:
   SCS3portfolio:
     Type: AWS::ServiceCatalog::Portfolio
@@ -93,38 +29,18 @@ Resources:
       ProviderName: !Ref 'PortfolioProvider'
       Description: !Ref 'PorfolioDescription'
       DisplayName: !Ref 'PorfolioName'
-  LaunchConstraintRole:
-    Type: AWS::CloudFormation::Stack
-    Condition: CreateLaunchConstraint
-    Properties:
-      TemplateURL: !Sub '${RepoRootURL}iam/sc-s3-launchrole.yaml'
-      TimeoutInMinutes: 5
   LinkEndusersRole:
     Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
-    Condition: CondPrincipalRoleName1
     Properties:
-      PrincipalARN: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${PrincipalRoleName1}'
+      PrincipalARN: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-RoleArn'
       PortfolioId: !Ref 'SCS3portfolio'
       PrincipalType: IAM
   LinkEndusersGroup:
     Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
-    Condition: CondPrincipalGroupName1
     Properties:
-      PrincipalARN: !Sub 'arn:aws:iam::${AWS::AccountId}:group/${PrincipalGroupName1}'
-      PortfolioId: !Ref 'SCS3portfolio'
-      PrincipalType: IAM
-  LinkEndusersAltRole:
-    Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
-    Condition: CondPrincipalRoleName2
-    Properties:
-      PrincipalARN: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${PrincipalRoleName2}'
-      PortfolioId: !Ref 'SCS3portfolio'
-      PrincipalType: IAM
-  LinkEndusersAltGroup:
-    Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
-    Condition: CondPrincipalGroupName2
-    Properties:
-      PrincipalARN: !Sub 'arn:aws:iam::${AWS::AccountId}:group/${PrincipalGroupName2}'
+      PrincipalARN: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-GroupArn'
       PortfolioId: !Ref 'SCS3portfolio'
       PrincipalType: IAM
   s3privateEncproduct:
@@ -132,10 +48,8 @@ Resources:
     Properties:
       Parameters:
         PortfolioProvider: !Ref 'PortfolioProvider'
-        LaunchConstraintARN: !If
-          - CreateLaunchConstraint
-          - !GetAtt 'LaunchConstraintRole.Outputs.LaunchRoleArn'
-          - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
+        LaunchConstraintARN: !ImportValue
+          'Fn::Sub': '${AWS::Region}-sc-s3-launchrole-LaunchRoleArn'
         PortfolioId: !Ref 'SCS3portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
         StackDatetime: !Ref StackDatetime
@@ -146,10 +60,8 @@ Resources:
     Properties:
       Parameters:
         PortfolioProvider: !Ref 'PortfolioProvider'
-        LaunchConstraintARN: !If
-          - CreateLaunchConstraint
-          - !GetAtt 'LaunchConstraintRole.Outputs.LaunchRoleArn'
-          - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
+        LaunchConstraintARN: !ImportValue
+          'Fn::Sub': '${AWS::Region}-sc-s3-launchrole-LaunchRoleArn'
         PortfolioId: !Ref 'SCS3portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
         StackDatetime: !Ref StackDatetime
@@ -161,3 +73,11 @@ Outputs:
     Value: !Ref SCS3portfolio
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-SCS3portfolioId'
+  s3privateEncproductId:
+    Value: !GetAtt 's3privateEncproduct.Outputs.ProductId'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-s3privateEncproductId'
+  s3synapseproductId:
+    Value: !GetAtt 's3synapseproduct.Outputs.ProductId'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-s3synapseproductId'


### PR DESCRIPTION
Refactor to use cross stack imports intead of passing in parameters.
We also removed unnessary paramters and make it more conducive for
sceptre deployment.

The main idea here is to make the template easier to understand for
preparation to remove 'AWS::CloudFormation::Stack' from this template