### PR TITLE
[SC-111] refactor to remove nested S3 stacks

### DIFF
--- a/s3/sc-portfolio-s3-basic.yaml
+++ b/s3/sc-portfolio-s3-basic.yaml
@@ -14,14 +14,6 @@ Parameters:
     Description: Portfolio Description
     Default: Service Catalog Portfolio that contains reference architecture products
       for Amazon Simple Storage Service.
-  RepoRootURL:
-    Type: String
-    Description: Root url for the repo containing the product templates.
-    Default: https://s3.amazonaws.com/aws-service-catalog-reference-architectures/
-  StackDatetime:
-    Type: String
-    Description: Last updated date and time of portfolio
-    Default: ''
 Resources:
   SCS3portfolio:
     Type: AWS::ServiceCatalog::Portfolio
@@ -43,41 +35,8 @@ Resources:
         'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-GroupArn'
       PortfolioId: !Ref 'SCS3portfolio'
       PrincipalType: IAM
-  s3privateEncproduct:
-    Type: AWS::CloudFormation::Stack
-    Properties:
-      Parameters:
-        PortfolioProvider: !Ref 'PortfolioProvider'
-        LaunchConstraintARN: !ImportValue
-          'Fn::Sub': '${AWS::Region}-sc-s3-launchrole-LaunchRoleArn'
-        PortfolioId: !Ref 'SCS3portfolio'
-        RepoRootURL: !Ref 'RepoRootURL'
-        StackDatetime: !Ref StackDatetime
-      TemplateURL: !Sub '${RepoRootURL}s3/sc-product-s3-private-enc.yaml'
-      TimeoutInMinutes: 5
-  s3synapseproduct:
-    Type: AWS::CloudFormation::Stack
-    Properties:
-      Parameters:
-        PortfolioProvider: !Ref 'PortfolioProvider'
-        LaunchConstraintARN: !ImportValue
-          'Fn::Sub': '${AWS::Region}-sc-s3-launchrole-LaunchRoleArn'
-        PortfolioId: !Ref 'SCS3portfolio'
-        RepoRootURL: !Ref 'RepoRootURL'
-        StackDatetime: !Ref StackDatetime
-      TemplateURL: !Sub '${RepoRootURL}s3/sc-product-s3-synapse.yaml'
-      TimeoutInMinutes: 5
-
 Outputs:
   SCS3portfolioId:
     Value: !Ref SCS3portfolio
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-SCS3portfolioId'
-  s3privateEncproductId:
-    Value: !GetAtt 's3privateEncproduct.Outputs.ProductId'
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-s3privateEncproductId'
-  s3synapseproductId:
-    Value: !GetAtt 's3synapseproduct.Outputs.ProductId'
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-s3synapseproductId'

--- a/s3/sc-product-s3-private-enc.yaml
+++ b/s3/sc-product-s3-private-enc.yaml
@@ -4,12 +4,7 @@ Parameters:
   PortfolioProvider:
     Type: String
     Description: Owner and Distributor Name
-  LaunchConstraintARN:
-    Type: String
-    Description: ARN of the launch constraint role for S3 products.
-  PortfolioId:
-    Type: String
-    Description: The ServiceCatalog portfolio this product will be attached to.
+    Default: IT Services
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
@@ -43,16 +38,19 @@ Resources:
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:
-      PortfolioId: !Ref 'PortfolioId'
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-s3-basic-SCS3portfolioId'
+      !Ref 'PortfolioId'
       ProductId: !Ref 'scs3product'
   constraintec2linux:
     Type: AWS::ServiceCatalog::LaunchRoleConstraint
     DependsOn: Associates3
     Properties:
-      PortfolioId: !Ref 'PortfolioId'
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-s3-basic-SCS3portfolioId'
       ProductId: !Ref 'scs3product'
-      RoleArn: !Ref 'LaunchConstraintARN'
-      Description: !Ref 'LaunchConstraintARN'
+      RoleArn: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-s3-launchrole-LaunchRoleArn'
 Outputs:
   ProductId:
     Value: !Ref 'scs3product'

--- a/s3/sc-product-s3-synapse.yaml
+++ b/s3/sc-product-s3-synapse.yaml
@@ -4,12 +4,7 @@ Parameters:
   PortfolioProvider:
     Type: String
     Description: Owner and Distributor Name
-  LaunchConstraintARN:
-    Type: String
-    Description: ARN of the launch constraint role for S3 products.
-  PortfolioId:
-    Type: String
-    Description: The ServiceCatalog portfolio this product will be attached to.
+    Default: IT Services
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
@@ -43,16 +38,19 @@ Resources:
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:
-      PortfolioId: !Ref 'PortfolioId'
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-s3-basic-SCS3portfolioId'
+      !Ref 'PortfolioId'
       ProductId: !Ref 'scs3product'
   constraintec2linux:
     Type: AWS::ServiceCatalog::LaunchRoleConstraint
     DependsOn: Associates3
     Properties:
-      PortfolioId: !Ref 'PortfolioId'
+      PortfolioId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-portfolio-s3-basic-SCS3portfolioId'
       ProductId: !Ref 'scs3product'
-      RoleArn: !Ref 'LaunchConstraintARN'
-      Description: !Ref 'LaunchConstraintARN'
+      RoleArn: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-s3-launchrole-LaunchRoleArn'
 Outputs:
   ProductId:
     Value: !Ref 'scs3product'


### PR DESCRIPTION
Nested stacks make things confusing and makes cloudformation
very difficult to test. We remove S3 nested stack and will deploy
stacks with sceptre. Scepter will manage the dependencies between
stacks.