### PR TITLE
Make product names configurable

### DIFF
--- a/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -15,6 +15,10 @@ Parameters:
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
+  ProductName:
+    Type: String
+    Description: Name of the product that will be visible to the end user
+    Default: 'Notebook Linux EC2 Instance with Jumpcloud Integration'
 Resources:
   ScEc2LinuxJumpcloudNotebookProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -24,7 +28,7 @@ Resources:
           ignore_checks:
             - E3002
     Properties:
-      Name: 'Notebook Linux EC2 Instance with Jumpcloud Integration'
+      Name: !Ref ProductName
       Description: This product builds one Linux EC2 instance using an Rstudio
         AMI based on Ubuntu and maintained by Sage Bionetworks.
       Owner: !Ref 'PortfolioProvider'

--- a/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -15,6 +15,10 @@ Parameters:
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
+  ProductName:
+    Type: String
+    Description: Name of the product that will be visible to the end user
+    Default: 'Workflows Linux EC2 Instance with Jumpcloud Integration'
 Resources:
   ScEc2LinuxJumpcloudWorkflowsProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -24,7 +28,7 @@ Resources:
           ignore_checks:
             - E3002
     Properties:
-      Name: 'Workflows Linux EC2 Instance with Jumpcloud Integration'
+      Name: !Ref ProductName
       Description: This product builds one Linux EC2 instance using an Ubuntu AMI
         with workflows software installed. Maintained by Sage Bionetworks. 
       Owner: !Ref 'PortfolioProvider'

--- a/ec2/sc-product-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud.yaml
@@ -15,6 +15,10 @@ Parameters:
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
+  ProductName:
+    Type: String
+    Description: Name of the product that will be visible to the end user
+    Default: 'EC2 Linux with Jumpcloud Integration'
 Resources:
   scec2linuxproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -24,7 +28,7 @@ Resources:
           ignore_checks:
             - E3002
     Properties:
-      Name: EC2 Linux with Jumpcloud Integration
+      Name: !Ref ProductName
       Description: This product builds one Linux EC2 instance, either
         Amazon Linux or Ubuntu, with Jumpcloud integration.
       Owner: !Ref 'PortfolioProvider'

--- a/ec2/sc-product-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-windows-jumpcloud.yaml
@@ -15,6 +15,10 @@ Parameters:
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
+  ProductName:
+    Type: String
+    Description: Name of the product that will be visible to the end user
+    Default: 'EC2 Windows with Jumpcloud Integration'
 Resources:
   scec2windowsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -24,7 +28,7 @@ Resources:
           ignore_checks:
             - E3002
     Properties:
-      Name: EC2 Windows with Jumpcloud Integration
+      Name: !Ref ProductName
       Description: This product builds one Microsoft Windows EC2 instance with
         Jumpcloud integration.
       Owner: !Ref 'PortfolioProvider'

--- a/s3/sc-product-s3-private-enc.yaml
+++ b/s3/sc-product-s3-private-enc.yaml
@@ -15,6 +15,10 @@ Parameters:
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
+  ProductName:
+    Type: String
+    Description: Name of the product that will be visible to the end user
+    Default: 'S3 Private Encrypted Bucket'
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -24,7 +28,7 @@ Resources:
           ignore_checks:
             - E3002
     Properties:
-      Name: S3 Private Encrypted Bucket
+      Name: !Ref ProductName
       Description: This product builds an AWS S3 bucket encrypted with private
         access accessible from any source.
       Owner: !Ref 'PortfolioProvider'

--- a/s3/sc-product-s3-synapse.yaml
+++ b/s3/sc-product-s3-synapse.yaml
@@ -15,6 +15,10 @@ Parameters:
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
+  ProductName:
+    Type: String
+    Description: Name of the product that will be visible to the end user
+    Default: 'S3 Synapse Bucket'
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -24,7 +28,7 @@ Resources:
           ignore_checks:
             - E3002
     Properties:
-      Name: S3 Synapse Bucket
+      Name: !Ref ProductName
       Description: This product builds an AWS S3 bucket with private access
         for Synapse.
       Owner: !Ref 'PortfolioProvider'


### PR DESCRIPTION
For SC-134 we need to make product names configurable, too. Otherwise, when testing the multiples of the same product appear in the list of possible products to provision for the user who is testing.