### PR TITLE
Allow reading role information in Linux instance profile

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -217,6 +217,7 @@ Resources:
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
         - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" 
+        - !Ref ReadAssumedRoleInformationPolicy
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -224,9 +225,20 @@ Resources:
             Principal:
               Service:
                 - ec2.amazonaws.com
-                - ssm.amazonaws.com #For maintenance service
+                - ssm.amazonaws.com 
             Action:
               - sts:AssumeRole
+  ReadAssumedRoleInformationPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+      Version: 2012-10-17
+      Statement:
+        - Sid: ReadAssumedRoleInformation
+          Effect: Allow
+          Action:
+            - "iam:GetRole"
+          Resource: "*"
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
This change allows an instance to read the roleid of a rolename in order to write a tag to itself. This permission set should be limited to Service Catalog instances that need to limit access to OIDC sessionNames. Thank you, @tthyer for raising the issue of instance profiles.