### PR TITLE
Sync with rename of imported stacks

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -217,7 +217,7 @@ Resources:
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-sc-remote-management-iam-ReadAssumedRoleInformationPolicy'
+          'Fn::Sub': '${AWS::Region}-get-role-policy-ReadAssumedRoleInformationPolicy'
         - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" 
       AssumeRolePolicyDocument:
         Version: '2012-10-17'


### PR DESCRIPTION
In scipool-infra, I changed the name of a stack that gets imported by instances in this library, so this corrects the stack name.