### PR TITLE
Remove the RequireEncryption property from SCS3BucketPolicy

### DIFF
--- a/s3/sc-s3-encrypted-ra-v1.0.0.yaml
+++ b/s3/sc-s3-encrypted-ra-v1.0.0.yaml
@@ -51,7 +51,6 @@ Resources:
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-bucket-policy-FunctionArn'
       BucketName: !Ref S3Bucket
       ExtraPrincipalArns: !Ref S3UserARNs
-      RequireEncryption: true
 Outputs:
   BucketName:
     Value: !Ref 'S3Bucket'


### PR DESCRIPTION
The RequireEncryption property is no longer necessary for the policy custom resource.
