### PR TITLE
replace ConnectionInstructions with  ConnectionURI

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
@@ -450,5 +450,5 @@ Outputs:
     Value: !Ref 'InstanceRole'
   IAMInstanceProfile:
     Value: !Ref 'InstanceProfile'
-  ConnectionInstructions:
-    Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"
+  ConnectionURI:
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${LinuxInstance}?region=${AWS::Region}"

--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -463,7 +463,5 @@ Outputs:
     Value: !Ref 'InstanceRole'
   IAMInstanceProfile:
     Value: !Ref 'InstanceProfile'
-  ConnectionInstructions:
-    Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"
   ConnectionURI:
     Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${LinuxInstance}?region=${AWS::Region}"

--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -446,5 +446,5 @@ Outputs:
     Value: !Ref 'InstanceRole'
   IAMInstanceProfile:
     Value: !Ref 'InstanceProfile'
-  ConnectionInstructions:
-    Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"
+  ConnectionURI:
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${LinuxInstance}?region=${AWS::Region}"

--- a/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
@@ -274,5 +274,5 @@ Outputs:
     Value: !Ref 'InstanceRole'
   IAMInstanceProfile:
     Value: !Ref 'InstanceProfile'
-  ConnectionInstructions:
-    Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"
+  ConnectionURI:
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${LinuxInstance}?region=${AWS::Region}"


### PR DESCRIPTION
Now that we have ConnectionURI to allow a direct SSH session
manager connection we no longer need the ConnectionInstructions