### PR TITLE
[SC-137] Fix jumpcloud integration

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
@@ -357,7 +357,7 @@ Resources:
                   -H 'Accept: application/json' \
                   -H 'Content-Type: application/json' \
                   -H x-api-key:$JC_SERVICE_API_KEY)
-                JC_USER_ID=$(echo $JC_SYSTEM_USERS | jq -r --arg EMAIL "$OWNER_EMAIL" '.results | .[] | select(.email==$EMAIL) | .id')
+                JC_USER_ID=$(echo $JC_SYSTEM_USERS | jq -r --arg EMAIL "$OWNER_EMAIL" '.results | .[] | select(.attributes[].value==$EMAIL) | .id')
                 /usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations \
                   -H 'Accept: application/json' \
                   -H 'Content-Type: application/json' \

--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -366,7 +366,7 @@ Resources:
                   -H 'Accept: application/json' \
                   -H 'Content-Type: application/json' \
                   -H x-api-key:$JC_SERVICE_API_KEY)
-                JC_USER_ID=$(echo $JC_SYSTEM_USERS | jq -r --arg EMAIL "$OWNER_EMAIL" '.results | .[] | select(.email==$EMAIL) | .id')
+                JC_USER_ID=$(echo $JC_SYSTEM_USERS | jq -r --arg EMAIL "$OWNER_EMAIL" '.results | .[] | select(.attributes[].value==$EMAIL) | .id')
                 /usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations \
                   -H 'Accept: application/json' \
                   -H 'Content-Type: application/json' \

--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -346,7 +346,7 @@ Resources:
                   -H 'Accept: application/json' \
                   -H 'Content-Type: application/json' \
                   -H x-api-key:$JC_SERVICE_API_KEY)
-                JC_USER=$(echo $JC_SYSTEM_USERS | jq --arg EMAIL "$OWNER_EMAIL" '.results | .[] | select(.email==$EMAIL)')
+                JC_USER_ID=$(echo $JC_SYSTEM_USERS | jq -r --arg EMAIL "$OWNER_EMAIL" '.results | .[] | select(.attributes[].value==$EMAIL) | .id')
                 JC_USER_ID=$(echo $JC_USER | jq -r '.id')
                 JC_USER_NAME=$(echo $JC_USER | jq -r '.username')
                 echo "$JC_USER_NAME" > /opt/sage/jcusername  # save JC user name for later

--- a/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
@@ -154,10 +154,10 @@ Resources:
         install_jc:
           files:
             'c:\scripts\install-ms-vc.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.3/aws/install-ms-vc.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.2/aws/install-ms-vc.ps1"
               mode: "0664"
             'c:\\scripts\\install-jc-agent.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.3/aws/install-jc-agent.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.2/aws/install-jc-agent.ps1"
               mode: "0664"
           commands:
             01_install_ms_vc:
@@ -176,7 +176,7 @@ Resources:
         config_jc:
           files:
             'c:\\scripts\\associate-jc-system.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.3/aws/sc/associate-jc-system.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.5/aws/associate-jc-system.ps1"
               mode: "0664"
           commands:
             01_associate_jc_systems:

--- a/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
@@ -154,10 +154,10 @@ Resources:
         install_jc:
           files:
             'c:\scripts\install-ms-vc.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.2/aws/install-ms-vc.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.3/aws/install-ms-vc.ps1"
               mode: "0664"
             'c:\\scripts\\install-jc-agent.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.2/aws/install-jc-agent.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.3/aws/install-jc-agent.ps1"
               mode: "0664"
           commands:
             01_install_ms_vc:
@@ -176,7 +176,7 @@ Resources:
         config_jc:
           files:
             'c:\\scripts\\associate-jc-system.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.2/aws/associate-jc-system.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.3/aws/sc/associate-jc-system.ps1"
               mode: "0664"
           commands:
             01_associate_jc_systems:


### PR DESCRIPTION
Created `SynapseEmail` attribute in jumpcloud and make instance
initilization use that value instead of the jumpcloud `email` value
to associate JC instances to users.

The SynapseEmail attribute would have a value like "jsmith@synapse.org"

I believe this also fixes issue SC-145

The windows fix depends on PR https://github.com/Sage-Bionetworks/infra-utils/pull/45
and will require a new infra-utils tag