### PR TITLE
Fix windows deployments

### DIFF
--- a/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
@@ -225,7 +225,7 @@ Resources:
                   - 'Powershell.exe C:\scripts\tag_instance.ps1 '
                   - ' > C:\scripts\tag-instance.log'
     Properties:
-      ImageId: 'ami-074545a6fb2313e2c'
+      ImageId: 'ami-0c278895328cddfdd'         # amazon/Windows_Server-2019-English-Full-Base-2020.04.15
       InstanceType: !Ref 'WindowsInstanceType'
       SubnetId: !ImportValue
         'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet1'


### PR DESCRIPTION
Provisioning windows throws the following error:
"API: ec2:RunInstances Not authorized for images: [ami-074545a6fb2313e2c]"

Apparently Windows AMI are deprecated when a new version is released:
https://stackoverflow.com/a/22665386/1094247

To fix we need to update to the latest supported AWS windows AMI

The real fix is to create own windows AMI using packer.