### PR TITLE
update windows instance type

### DIFF
--- a/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
@@ -26,7 +26,7 @@ Parameters:
       - t3.medium
       - t3.large
       - t3.xlarge
-    Default: t3.micro
+    Default: t3.small
     Description: Amazon EC2 Instance Type
     Type: String
   VolumeSize:


### PR DESCRIPTION
t3.nano and t3.micro can be used just to run services but would
be way too under powered for RDP sessions.  t3.small is probably
the minimal required for RDP. Update to match most common use case