### PR TITLE
Use ReplaceProvisioningArtifacts in product templates to allow product version template updates

### DIFF
--- a/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -8,10 +8,6 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  StackDatetime:
-    Type: String
-    Description: Last updated date and time of portfolio
-    Default: ''
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
@@ -34,14 +30,15 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: !Sub 'Baseline version. Last portfolio update occurred at ${StackDatetime}.'
+        - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml'
-          Name: v1.0.0
+          Name: 'v1.0.0'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
           Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
+      ReplaceProvisioningArtifacts: true
   Associateec2linux:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -8,10 +8,6 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  StackDatetime:
-    Type: String
-    Description: Last updated date and time of portfolio
-    Default: ''
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
@@ -34,14 +30,15 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: !Sub 'Baseline version. Last portfolio update occurred at ${StackDatetime}.'
+        - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml'
-          Name: v1.0.0
+          Name: 'v1.0.0'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
           Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
+      ReplaceProvisioningArtifacts: true
   Associateec2linux:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud.yaml
@@ -8,10 +8,6 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  StackDatetime:
-    Type: String
-    Description: Last updated date and time of portfolio
-    Default: ''
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
@@ -34,14 +30,15 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: !Sub 'Baseline version. Last portfolio update occurred at ${StackDatetime}.'
+        - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml'
-          Name: v1.0.0
+          Name: 'v1.0.0'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
           Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
+      ReplaceProvisioningArtifacts: true
   Associateec2linux:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-windows-jumpcloud.yaml
@@ -8,10 +8,6 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  StackDatetime:
-    Type: String
-    Description: Last updated date and time of portfolio
-    Default: ''
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
@@ -34,14 +30,15 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: !Sub 'Baseline version. Last portfolio update occurred at ${StackDatetime}.'
+        - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml'
-          Name: v1.0.0
+          Name: 'v1.0.0'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
           Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
+      ReplaceProvisioningArtifacts: true
   Associateec2windows:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-enc.yaml
+++ b/s3/sc-product-s3-private-enc.yaml
@@ -8,10 +8,6 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  StackDatetime:
-    Type: String
-    Description: Last updated date and time of portfolio
-    Default: ''
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
@@ -34,14 +30,15 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: !Sub 'Baseline version. Last portfolio update occurred at ${StackDatetime}.'
+        - Description: 'Baseline version'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-encrypted-ra-v1.0.0.yaml'
-          Name: v1.0.0
+          Name: 'v1.0.0'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
           Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
+      ReplaceProvisioningArtifacts: true
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-synapse.yaml
+++ b/s3/sc-product-s3-synapse.yaml
@@ -8,10 +8,6 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  StackDatetime:
-    Type: String
-    Description: Last updated date and time of portfolio
-    Default: ''
   PortfolioId:
     Type: String
     Description: ID of the portfolio that will contain this product
@@ -34,14 +30,15 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: !Sub 'Baseline version. Last portfolio update occurred at ${StackDatetime}.'
+        - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-synapse-ra-v1.0.0.yaml'
-          Name: v1.0.0
+          Name: 'v1.0.0'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
           Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
+      ReplaceProvisioningArtifacts: true
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:


### PR DESCRIPTION
This replaces the hack using StackDatetime with the new property ReplaceProvisioningArtifacts for forcing update of the `LoadTemplateFromUrl` template content in product versions.

This PR is dependent upon https://github.com/Sage-Bionetworks/scipool-infra/pull/124.