### PR TITLE
[SC-145] Fix jumpcloud integration

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
@@ -275,12 +275,12 @@ Resources:
             - cfn_hup_service
           SetEnv:
             - set_env_vars
-          SetupJumpcloud:
-            - install_jc
-            - config_jc
           SetTags:
             - TagRootVolume
             - TagInstance
+          SetupJumpcloud:
+            - install_jc
+            - config_jc
         cfn_hup_service:
           files:
             /etc/cfn/cfn-hup.conf:
@@ -298,7 +298,7 @@ Resources:
                 [cfn-auto-reloader-hook]
                 triggers=post.update
                 path=Resources.LinuxInstance.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetTags --region ${AWS::Region}
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetTags,SetupJumpcloud --region ${AWS::Region}
               mode: "000400"
               owner: root
               group: root
@@ -345,34 +345,12 @@ Resources:
                   - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcConnectKey"}}
                   - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
         config_jc:
-          files:
-            /opt/sage/bin/associate_jc_systems.sh:
-              content: !Sub |
-                #! /bin/bash
-
-                source /opt/sage/bin/instance_env_vars.sh
-                JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey')
-                JC_SYSTEM_USERS=$(/usr/bin/curl --silent --show-error -X GET \
-                  https://console.jumpcloud.com/api/systemusers \
-                  -H 'Accept: application/json' \
-                  -H 'Content-Type: application/json' \
-                  -H x-api-key:$JC_SERVICE_API_KEY)
-                JC_USER_ID=$(echo $JC_SYSTEM_USERS | jq -r --arg EMAIL "$OWNER_EMAIL" '.results | .[] | select(.attributes[].value==$EMAIL) | .id')
-                /usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations \
-                  -H 'Accept: application/json' \
-                  -H 'Content-Type: application/json' \
-                  -H x-api-key:$JC_SERVICE_API_KEY \
-                  -d '{"attributes":{"sudo":{"enabled":true,"withoutPassword":false}},"op":"add","type":"system","id":"'$JC_SYSTEM_ID'"}'
-
-              mode: "00744"
-              owner: "root"
-              group: "root"
           commands:
             # allow agent time to register with jumpcloud account
             01_wait_registration:
               command: "sleep 10"
             02_associate_jc_systems:
-              command: "/opt/sage/bin/associate_jc_systems.sh"
+              command: "source /opt/sage/bin/instance_env_vars.sh && /opt/sage/bin/associate_jc_systems.py"
               env:
                 JC_SERVICE_API_KEY:
                   Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}
@@ -420,7 +398,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetTags --region ${AWS::Region}
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetTags,SetupJumpcloud --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
       Tags:
         - Key: Name

--- a/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
@@ -345,12 +345,18 @@ Resources:
                   - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcConnectKey"}}
                   - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
         config_jc:
+          files:
+            /opt/sage/bin/associate_jc_systems.py:
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.3/linux/opt/sage/bin/associate_jc_systems.py"
+              mode: "00744"
+              owner: "root"
+              group: "root"
           commands:
             # allow agent time to register with jumpcloud account
             01_wait_registration:
               command: "sleep 10"
             02_associate_jc_systems:
-              command: "source /opt/sage/bin/instance_env_vars.sh && /opt/sage/bin/associate_jc_systems.py"
+              command: "source /opt/sage/bin/instance_env_vars.sh && /usr/bin/python3 /opt/sage/bin/associate_jc_systems.py"
               env:
                 JC_SERVICE_API_KEY:
                   Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}

--- a/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
@@ -325,7 +325,7 @@ Resources:
         set_env_vars:
           files:
             /opt/sage/bin/make_env_vars_file.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.0/linux/opt/sage/bin/make_env_vars_file.sh"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.3/linux/opt/sage/bin/make_env_vars_file.sh"
               mode: "00744"
               owner: "root"
               group: "root"
@@ -372,7 +372,7 @@ Resources:
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.2/linux/opt/sage/bin/apply_name_tag.sh"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.3/linux/opt/sage/bin/apply_name_tag.sh"
               mode: "00744"
               owner: "root"
               group: "root"

--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -334,7 +334,7 @@ Resources:
         set_env_vars:
           files:
             /opt/sage/bin/make_env_vars_file.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.1/linux/opt/sage/bin/make_env_vars_file.sh"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.3/linux/opt/sage/bin/make_env_vars_file.sh"
               mode: "00744"
               owner: "root"
               group: "root"
@@ -354,12 +354,18 @@ Resources:
                   - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcConnectKey"}}
                   - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
         config_jc:
+          files:
+            /opt/sage/bin/associate_jc_systems.py:
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.3/linux/opt/sage/bin/associate_jc_systems.py"
+              mode: "00744"
+              owner: "root"
+              group: "root"
           commands:
             # allow agent time to register with jumpcloud account
             01_wait_registration:
               command: "sleep 10"
             02_associate_jc_systems:
-              command: "source /opt/sage/bin/instance_env_vars.sh && /opt/sage/bin/associate_jc_systems.py"
+              command: "source /opt/sage/bin/instance_env_vars.sh && /usr/bin/python3 /opt/sage/bin/associate_jc_systems.py"
               env:
                 JC_SERVICE_API_KEY:
                   Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}
@@ -375,7 +381,7 @@ Resources:
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.2/linux/opt/sage/bin/apply_name_tag.sh"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.3/linux/opt/sage/bin/apply_name_tag.sh"
               mode: "00744"
               owner: "root"
               group: "root"

--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -284,12 +284,12 @@ Resources:
             - cfn_hup_service
           SetEnv:
             - set_env_vars
-          SetupJumpcloud:
-            - install_jc
-            - config_jc
           SetTags:
             - TagRootVolume
             - TagInstance
+          SetupJumpcloud:
+            - install_jc
+            - config_jc
         cfn_hup_service:
           files:
             /etc/cfn/cfn-hup.conf:
@@ -307,7 +307,7 @@ Resources:
                 [cfn-auto-reloader-hook]
                 triggers=post.update
                 path=Resources.LinuxInstance.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetTags --region ${AWS::Region}
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetTags,SetupJumpcloud --region ${AWS::Region}
               mode: "000400"
               owner: root
               group: root
@@ -354,34 +354,12 @@ Resources:
                   - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcConnectKey"}}
                   - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
         config_jc:
-          files:
-            /opt/sage/bin/associate_jc_systems.sh:
-              content: !Sub |
-                #! /bin/bash
-
-                source /opt/sage/bin/instance_env_vars.sh
-                JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey')
-                JC_SYSTEM_USERS=$(/usr/bin/curl --silent --show-error -X GET \
-                  https://console.jumpcloud.com/api/systemusers \
-                  -H 'Accept: application/json' \
-                  -H 'Content-Type: application/json' \
-                  -H x-api-key:$JC_SERVICE_API_KEY)
-                JC_USER_ID=$(echo $JC_SYSTEM_USERS | jq -r --arg EMAIL "$OWNER_EMAIL" '.results | .[] | select(.attributes[].value==$EMAIL) | .id')
-                /usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations \
-                  -H 'Accept: application/json' \
-                  -H 'Content-Type: application/json' \
-                  -H x-api-key:$JC_SERVICE_API_KEY \
-                  -d '{"attributes":{"sudo":{"enabled":true,"withoutPassword":false}},"op":"add","type":"system","id":"'$JC_SYSTEM_ID'"}'
-
-              mode: "00744"
-              owner: "root"
-              group: "root"
           commands:
             # allow agent time to register with jumpcloud account
             01_wait_registration:
               command: "sleep 10"
             02_associate_jc_systems:
-              command: "/opt/sage/bin/associate_jc_systems.sh"
+              command: "source /opt/sage/bin/instance_env_vars.sh && /opt/sage/bin/associate_jc_systems.py"
               env:
                 JC_SERVICE_API_KEY:
                   Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}
@@ -429,7 +407,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetTags --region ${AWS::Region}
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetTags,SetupJumpcloud --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
       Tags:
         - Key: Name

--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -262,12 +262,12 @@ Resources:
             - cfn_hup_service
           SetEnv:
             - set_env_vars
-          SetupJumpcloud:
-            - install_jc
-            - config_jc
           SetTags:
             - TagRootVolume
             - TagInstance
+          SetupJumpcloud:
+            - install_jc
+            - config_jc
           SetupDocker:
             - add_docker_user
         cfn_hup_service:
@@ -287,7 +287,7 @@ Resources:
                 [cfn-auto-reloader-hook]
                 triggers=post.update
                 path=Resources.LinuxInstance.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetTags,SetupDocker --region ${AWS::Region}
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetTags,SetupJumpcloud,SetupDocker --region ${AWS::Region}
               mode: "000400"
               owner: root
               group: root
@@ -334,37 +334,12 @@ Resources:
                   - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcConnectKey"}}
                   - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
         config_jc:
-          files:
-            /opt/sage/bin/associate_jc_systems.sh:
-              content: !Sub |
-                #! /bin/bash
-
-                source /opt/sage/bin/instance_env_vars.sh
-                JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey')
-                JC_SYSTEM_USERS=$(/usr/bin/curl --silent --show-error -X GET \
-                  https://console.jumpcloud.com/api/systemusers \
-                  -H 'Accept: application/json' \
-                  -H 'Content-Type: application/json' \
-                  -H x-api-key:$JC_SERVICE_API_KEY)
-                JC_USER_ID=$(echo $JC_SYSTEM_USERS | jq -r --arg EMAIL "$OWNER_EMAIL" '.results | .[] | select(.attributes[].value==$EMAIL) | .id')
-                JC_USER_ID=$(echo $JC_USER | jq -r '.id')
-                JC_USER_NAME=$(echo $JC_USER | jq -r '.username')
-                echo "$JC_USER_NAME" > /opt/sage/jcusername  # save JC user name for later
-                /usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations \
-                  -H 'Accept: application/json' \
-                  -H 'Content-Type: application/json' \
-                  -H x-api-key:$JC_SERVICE_API_KEY \
-                  -d '{"attributes":{"sudo":{"enabled":true,"withoutPassword":false}},"op":"add","type":"system","id":"'$JC_SYSTEM_ID'"}'
-
-              mode: "00744"
-              owner: "root"
-              group: "root"
           commands:
             # allow agent time to register with jumpcloud account
             01_wait_registration:
               command: "sleep 10"
             02_associate_jc_systems:
-              command: "/opt/sage/bin/associate_jc_systems.sh"
+              command: "source /opt/sage/bin/instance_env_vars.sh && /opt/sage/bin/associate_jc_systems.py"
               env:
                 JC_SERVICE_API_KEY:
                   Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}
@@ -416,7 +391,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetTags,SetupDocker --region ${AWS::Region}
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetTags,SetupJumpcloud,SetupDocker --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
       Tags:
         - Key: Name

--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -334,12 +334,18 @@ Resources:
                   - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcConnectKey"}}
                   - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
         config_jc:
+          files:
+            /opt/sage/bin/associate_jc_systems.py:
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.3/linux/opt/sage/bin/associate_jc_systems.py"
+              mode: "00744"
+              owner: "root"
+              group: "root"
           commands:
             # allow agent time to register with jumpcloud account
             01_wait_registration:
               command: "sleep 10"
             02_associate_jc_systems:
-              command: "source /opt/sage/bin/instance_env_vars.sh && /opt/sage/bin/associate_jc_systems.py"
+              command: "source /opt/sage/bin/instance_env_vars.sh && /usr/bin/python3 /opt/sage/bin/associate_jc_systems.py"
               env:
                 JC_SERVICE_API_KEY:
                   Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}

--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -314,7 +314,7 @@ Resources:
         set_env_vars:
           files:
             /opt/sage/bin/make_env_vars_file.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.0/linux/opt/sage/bin/make_env_vars_file.sh"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.3/linux/opt/sage/bin/make_env_vars_file.sh"
               mode: "00744"
               owner: "root"
               group: "root"
@@ -361,7 +361,7 @@ Resources:
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.2/linux/opt/sage/bin/apply_name_tag.sh"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.3/linux/opt/sage/bin/apply_name_tag.sh"
               mode: "00744"
               owner: "root"
               group: "root"


### PR DESCRIPTION
Use the new service-catalog-utils file to fix jumpcloud integration with
provisioned instances

* Switch ordering of SetupJumpcloud and SetTags.  Tagging volume and
  instance should run before setting up jumpcloud integration
* run new python script to associate EC2 instances to a JC user

This PR depends on PR https://github.com/Sage-Bionetworks/service-catalog-utils/pull/6
and will require a new tag of service-catalog-utils