### PR TITLE
[SC-156] update to latest workflow AMI

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -373,7 +373,7 @@ Resources:
             01_add_jc_user_to_docker_group:
               command: "gpasswd -a $(cat /opt/sage/jcusername) docker"
     Properties:
-      ImageId: "ami-0e42922cf0e599fbc"  # https://github.com/Sage-Bionetworks-IT/packer-workflows/releases/tag/v1.0.2
+      ImageId: "ami-022e9a10f00f8ab9a"  # https://github.com/Sage-Bionetworks-IT/packer-workflows/releases/tag/v1.0.5
       InstanceType: !Ref 'EC2InstanceType'
       SubnetId: !If
         - UsePublicSubnet


### PR DESCRIPTION
Old workflow AMI was created as a private AMI which caused the
following failure when deployed with the SC:

  API: ec2:RunInstances Not authorized for images: [ami-01866cea595e4f968]

The newer AMI built as a public AMI so it should fix this issue.