### PR TITLE
Re-add StackDatetime to trigger version update in products

### DIFF
--- a/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -15,6 +15,10 @@ Parameters:
     Type: String
     Description: Name of the product that will be visible to the end user
     Default: 'Notebook Linux EC2 Instance with Jumpcloud Integration'
+  StackDatetime:
+    Type: String
+    Description: Last updated date and time of product
+    Default: ''
 Resources:
   ScEc2LinuxJumpcloudNotebookProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +34,7 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: 'Baseline version.'
+        - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml'
           Name: 'v1.0.0'

--- a/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -15,6 +15,10 @@ Parameters:
     Type: String
     Description: Name of the product that will be visible to the end user
     Default: 'Workflows Linux EC2 Instance with Jumpcloud Integration'
+  StackDatetime:
+    Type: String
+    Description: Last updated date and time of product
+    Default: ''
 Resources:
   ScEc2LinuxJumpcloudWorkflowsProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +34,7 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: 'Baseline version.'
+        - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml'
           Name: 'v1.0.0'

--- a/ec2/sc-product-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud.yaml
@@ -15,6 +15,10 @@ Parameters:
     Type: String
     Description: Name of the product that will be visible to the end user
     Default: 'EC2 Linux with Jumpcloud Integration'
+  StackDatetime:
+    Type: String
+    Description: Last updated date and time of product
+    Default: ''
 Resources:
   scec2linuxproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +34,7 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: 'Baseline version.'
+        - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml'
           Name: 'v1.0.0'

--- a/ec2/sc-product-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-windows-jumpcloud.yaml
@@ -15,6 +15,10 @@ Parameters:
     Type: String
     Description: Name of the product that will be visible to the end user
     Default: 'EC2 Windows with Jumpcloud Integration'
+  StackDatetime:
+    Type: String
+    Description: Last updated date and time of product
+    Default: ''
 Resources:
   scec2windowsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +34,7 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: 'Baseline version.'
+        - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml'
           Name: 'v1.0.0'

--- a/s3/sc-product-s3-private-enc.yaml
+++ b/s3/sc-product-s3-private-enc.yaml
@@ -15,6 +15,10 @@ Parameters:
     Type: String
     Description: Name of the product that will be visible to the end user
     Default: 'S3 Private Encrypted Bucket'
+  StackDatetime:
+    Type: String
+    Description: Last updated date and time of product
+    Default: ''
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +34,7 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: 'Baseline version'
+        - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-encrypted-ra-v1.0.0.yaml'
           Name: 'v1.0.0'

--- a/s3/sc-product-s3-synapse.yaml
+++ b/s3/sc-product-s3-synapse.yaml
@@ -15,6 +15,10 @@ Parameters:
     Type: String
     Description: Name of the product that will be visible to the end user
     Default: 'S3 Synapse Bucket'
+  StackDatetime:
+    Type: String
+    Description: Last updated date and time of product
+    Default: ''
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +34,7 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: 'Baseline version.'
+        - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-synapse-ra-v1.0.0.yaml'
           Name: 'v1.0.0'


### PR DESCRIPTION
We need to make an update to one of the fields of the version to actually trigger an update, as it appears that simply changing the template content does not do this. Adding StackDatetime back into description for that purpose. 

After this is merged I will revert https://github.com/Sage-Bionetworks/scipool-infra/pull/124.