### PR TITLE
SC-143

### DIFF
--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -30,12 +30,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-              # Synapse OIDC identity provider
-              Federated: !Sub 'arn:aws:iam::${AWS::AccountId}:oidc-provider/repo-prod.prod.sagebase.org/auth/v1'
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:role/synapse-login-scipooldev-InstanceRole-*'
             Action:
-              - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:AssumeRole'
+              - 'sts:TagSession'
   SCEnduserExpandedPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:

--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -30,10 +30,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: *
+              AWS: "*"
             Condition:
               StringLike:
-                iam:PrincipalArn: arn:aws:iam::${AWS::AccountId}:role/synapse-login-scipool*-InstanceRole-*
+                iam:PrincipalArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/synapse-login-scipool*-InstanceRole-*'
             Action:
               - 'sts:AssumeRole'
               - 'sts:TagSession'

--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -30,7 +30,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:role/synapse-login-scipooldev-InstanceRole-*'
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:role/synapse-login-scipool*-InstanceRole-*'
             Action:
               - 'sts:AssumeRole'
               - 'sts:TagSession'

--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -30,7 +30,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:role/synapse-login-scipool*-InstanceRole-*'
+              AWS: *
+            Condition:
+              StringLike:
+                iam:PrincipalArn: arn:aws:iam::${AWS::AccountId}:role/synapse-login-scipool*-InstanceRole-*
             Action:
               - 'sts:AssumeRole'
               - 'sts:TagSession'


### PR DESCRIPTION
This is a revision to the change in the trust relationship to allow only the login app' role to assume the ServiceCatalogEndUsers role.   I validated that this works by manually applying it to the dev' scipool account.