### PR TITLE
Replace source command with '.'

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
@@ -358,7 +358,7 @@ Resources:
             01_wait_registration:
               command: "sleep 10"
             02_associate_jc_systems:
-              command: "source /opt/sage/bin/instance_env_vars.sh && /usr/bin/python3 /opt/sage/bin/associate_jc_systems.py"
+              command: ". /opt/sage/bin/instance_env_vars.sh && /usr/bin/python3 /opt/sage/bin/associate_jc_systems.py"
               env:
                 JC_SERVICE_API_KEY:
                   Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}

--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -347,7 +347,7 @@ Resources:
             01_wait_registration:
               command: "sleep 10"
             02_associate_jc_systems:
-              command: "source /opt/sage/bin/instance_env_vars.sh && /usr/bin/python3 /opt/sage/bin/associate_jc_systems.py"
+              command: ". /opt/sage/bin/instance_env_vars.sh && /usr/bin/python3 /opt/sage/bin/associate_jc_systems.py"
               env:
                 JC_SERVICE_API_KEY:
                   Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}


### PR DESCRIPTION
Apparently the notebook and workflow instances don't know the
source command so @tthyer suggest replacing it with the period.

Error during instance initilization:
[ERROR] Command 02_associate_jc_systems (source /opt/sage/bin/instance_env_vars.sh && /usr/bin/python3 /opt/sage/bin/associate_jc_systems.py) failed
[DEBUG] Command 02_associate_jc_systems output: /bin/sh: 1: source: not found