### PR TITLE
Increase default volume size

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -181,8 +181,8 @@ Parameters:
   VolumeSize:
     Description: The EC2 volume size (in GB)
     Type: Number
-    Default: 8
-    MinValue: 8
+    Default: 16
+    MinValue: 16
     MaxValue: 2000
 Conditions:
   UsePublicSubnet: !Equals [!Ref PrivateNetwork, 'false']


### PR DESCRIPTION
We recently change the packer-workflows AMI to default to
16GB so set the default in the CFN template to match.

AMI change was in PR https://github.com/Sage-Bionetworks-IT/packer-workflows/pull/8