### PR TITLE
Replace source with '.'

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -365,7 +365,7 @@ Resources:
             01_wait_registration:
               command: "sleep 10"
             02_associate_jc_systems:
-              command: "source /opt/sage/bin/instance_env_vars.sh && /usr/bin/python3 /opt/sage/bin/associate_jc_systems.py"
+              command: ". /opt/sage/bin/instance_env_vars.sh && /usr/bin/python3 /opt/sage/bin/associate_jc_systems.py"
               env:
                 JC_SERVICE_API_KEY:
                   Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}


### PR DESCRIPTION
Apparently '.' is more portable than source so changing it out
similar to commit eb06a0641