### PR TITLE
[SC-123] remove OwnerEmail tag option

### DIFF
--- a/common/sc-tag-options.j2
+++ b/common/sc-tag-options.j2
@@ -17,14 +17,6 @@ Resources:
       Key: "Project"
       Value: {{ project }}
 {% endfor %}
-{% for email in sceptre_user_data.OwnerEmails %}
-  {{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag:
-    Type: AWS::ServiceCatalog::TagOption
-    Properties:
-      Active: true
-      Key: "OwnerEmail"
-      Value: {{ email }}
-{% endfor %}
 
 {% for id in sceptre_user_data.ProductIDs %}
   {% for department in sceptre_user_data.Departments %}
@@ -41,13 +33,6 @@ Resources:
       ResourceId: "{{ id }}"
       TagOptionId: !Ref "{{ project.replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag"
   {% endfor %}
-  {% for email in sceptre_user_data.OwnerEmails %}
-  {{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}TagAssociationProd{{ id.split('-')[1] }}:
-    Type: AWS::ServiceCatalog::TagOptionAssociation
-    Properties:
-      ResourceId: "{{ id }}"
-      TagOptionId: !Ref "{{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag"
-  {% endfor %}
 {% endfor %}
 
 Outputs:
@@ -62,10 +47,4 @@ Outputs:
     Value: !Ref "{{ project.replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag"
     Export:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-{{ project.replace('.','').replace('-','').replace('_','').replace('/','') }}ProjectTag"
-{% endfor %}
-{% for email in sceptre_user_data.OwnerEmails %}
-  {{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag:
-    Value: !Ref "{{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag"
-    Export:
-      Name: !Sub "${AWS::Region}-${AWS::StackName}-{{ email.split('@')[0].replace('.','').replace('-','').replace('_','') }}OwnerEmailTag"
 {% endfor %}


### PR DESCRIPTION
The OwnerEmail tag is automatically applied by the provisioner now
so we no longer a tag option for it.