### PR TITLE
Remove Windows ConnectionURI

### DIFF
--- a/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
@@ -276,5 +276,3 @@ Outputs:
     Value: !Ref 'InstanceProfile'
   ConnectionInstructions:
     Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"
-  ConnectionURI:
-    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${WindowsInstance}?region=${AWS::Region}"


### PR DESCRIPTION
Remove the Windows ConnectionURI link. When clicked upon, an error was displayed that looks like this: `User: arn:aws:sts::237179673806:assumed-role/ServiceCatalogEndusers/273960 is not authorized to perform: ssm:StartSession on resource: arn:aws:ec2:us-east-1:237179673806:instance/i-0a1f5c66df1ecf2f6`. There isn't a compelling use case for providing Powershell sessions, so we're going to just remove the link.
