### PR TITLE
[SC-30] Re-use VpnSecurityGroup

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
@@ -216,25 +216,6 @@ Resources:
       Path: /
       Roles:
         - !Ref 'InstanceRole'
-  PrivateSubnetSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: >-
-        Allow all traffic to an instance originating from the VPN
-      VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
-      SecurityGroupIngress:
-        - CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
-          FromPort: -1
-          ToPort: -1
-          IpProtocol: '-1'
-          Description: 'Allow all VPN traffic'
-      SecurityGroupEgress:
-        - CidrIp: 0.0.0.0/0
-          FromPort: -1
-          ToPort: -1
-          IpProtocol: '-1'
   LinuxInstance:
     Type: AWS::EC2::Instance
     Metadata:
@@ -358,7 +339,7 @@ Resources:
       SubnetId: !ImportValue
         'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
       SecurityGroupIds:
-        - !Ref PrivateSubnetSecurityGroup
+        - 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-VpnSecurityGroup'
       KeyName: 'scipool'
       BlockDeviceMappings:
         -

--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -221,25 +221,6 @@ Resources:
       Path: /
       Roles:
         - !Ref 'InstanceRole'
-  PrivateSubnetSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: >-
-        Allow all traffic to an instance originating from the VPN
-      VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
-      SecurityGroupIngress:
-        - CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
-          FromPort: -1
-          ToPort: -1
-          IpProtocol: '-1'
-          Description: 'Allow all VPN traffic'
-      SecurityGroupEgress:
-        - CidrIp: 0.0.0.0/0
-          FromPort: -1
-          ToPort: -1
-          IpProtocol: '-1'
   LinuxInstance:
     Type: AWS::EC2::Instance
     Metadata:
@@ -363,7 +344,7 @@ Resources:
       SubnetId: !ImportValue
         'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
       SecurityGroupIds:
-        - !Ref PrivateSubnetSecurityGroup
+        - 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-VpnSecurityGroup'
       KeyName: 'scipool'
       BlockDeviceMappings:
         -

--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -203,25 +203,6 @@ Resources:
       Path: /
       Roles:
         - !Ref 'InstanceRole'
-  PrivateSubnetSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: >-
-        Allow all traffic to an instance originating from the VPN
-      VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
-      SecurityGroupIngress:
-        - CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
-          FromPort: -1
-          ToPort: -1
-          IpProtocol: '-1'
-          Description: 'Allow all VPN traffic'
-      SecurityGroupEgress:
-        - CidrIp: 0.0.0.0/0
-          FromPort: -1
-          ToPort: -1
-          IpProtocol: '-1'
   LinuxInstance:
     Type: AWS::EC2::Instance
     Metadata:
@@ -351,7 +332,7 @@ Resources:
       SubnetId: !ImportValue
         'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
       SecurityGroupIds:
-        - !Ref PrivateSubnetSecurityGroup
+        - 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-VpnSecurityGroup'
       KeyName: 'scipool'
       BlockDeviceMappings:
         -

--- a/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
@@ -62,23 +62,6 @@ Resources:
       Path: /
       Roles:
         - !Ref 'InstanceRole'
-  WindowsSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Enables RDP Access to Windows EC2 Instance
-      VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
-      SecurityGroupIngress:
-        - Description: allow RDP
-          IpProtocol: tcp
-          FromPort: 3389
-          ToPort: 3389
-          CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
-      SecurityGroupEgress:
-        - Description: allow all outgoing
-          IpProtocol: '-1'
-          CidrIp: '0.0.0.0/0'
   WindowsInstance:
     Type: AWS::EC2::Instance
     Metadata:
@@ -230,7 +213,7 @@ Resources:
       SubnetId: !ImportValue
         'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet1'
       SecurityGroupIds:
-        - !Ref 'WindowsSecurityGroup'
+        - 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-VpnSecurityGroup'
       KeyName: 'scipool'
       IamInstanceProfile: !Ref 'InstanceProfile'
       BlockDeviceMappings:


### PR DESCRIPTION
Instead of creating a new PrivateSubnetSecurityGroups for every EC2 instance
use VpnSecurityGroup export from internalpoolvpc.