### PR TITLE
Replace support with products snippet

### DIFF
--- a/ec2/sc-portfolio-ec2.yaml
+++ b/ec2/sc-portfolio-ec2.yaml
@@ -4,16 +4,15 @@ Parameters:
   PortfolioProvider:
     Type: String
     Description: Provider Name
-    Default: IT Services
+    Default: Sage Bionetworks
   PorfolioName:
     Type: String
     Description: Portfolio Name
-    Default: Service Catalog EC2 Reference Architecture
+    Default: EC2 Portfolio
   PorfolioDescription:
     Type: String
     Description: Portfolio Description
-    Default: Service Catalog Portfolio that contains reference architecture products
-      for Amazon Elastic Compute Cloud (EC2).
+    Default: Portfolio of EC2 products
 Resources:
   SCEC2portfolio:
     Type: AWS::ServiceCatalog::Portfolio

--- a/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -1,10 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'Notebook Linux EC2 ServiceCatalog product with Jumpcloud integration.'
 Parameters:
-  PortfolioProvider:
-    Type: String
-    Description: Owner and Distributor Name
-    Default: IT Services
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
@@ -27,12 +23,12 @@ Resources:
         config:
           ignore_checks:
             - E3002
+            - E3003
+            - W2001
     Properties:
       Name: !Ref ProductName
       Description: This product builds one Linux EC2 instance using an Rstudio
         AMI based on Ubuntu and maintained by Sage Bionetworks.
-      Owner: !Ref 'PortfolioProvider'
-      Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
         - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:

--- a/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -37,6 +37,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
+          # source: https://github.com/Sage-Bionetworks/admincentral-infra/blob/master/templates/cfn-snippets-bucket.yaml
           Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
       ReplaceProvisioningArtifacts: true
   Associateec2linux:

--- a/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -1,10 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'Workflows Linux EC2 ServiceCatalog product with Jumpcloud integration.'
 Parameters:
-  PortfolioProvider:
-    Type: String
-    Description: Owner and Distributor Name
-    Default: IT Services
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
@@ -27,12 +23,12 @@ Resources:
         config:
           ignore_checks:
             - E3002
+            - E3003
+            - W2001
     Properties:
       Name: !Ref ProductName
       Description: This product builds one Linux EC2 instance using an Ubuntu AMI
         with workflows software installed. Maintained by Sage Bionetworks.
-      Owner: !Ref 'PortfolioProvider'
-      Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
         - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:

--- a/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -37,6 +37,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
+          # source: https://github.com/Sage-Bionetworks/admincentral-infra/blob/master/templates/cfn-snippets-bucket.yaml
           Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
       ReplaceProvisioningArtifacts: true
   Associateec2linux:

--- a/ec2/sc-product-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud.yaml
@@ -37,6 +37,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
+          # source: https://github.com/Sage-Bionetworks/admincentral-infra/blob/master/templates/cfn-snippets-bucket.yaml
           Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipool/products.yaml"
       ReplaceProvisioningArtifacts: true
   Associateec2linux:

--- a/ec2/sc-product-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud.yaml
@@ -1,10 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Linux EC2 ServiceCatalog product with Jumpcloud integration.
 Parameters:
-  PortfolioProvider:
-    Type: String
-    Description: Owner and Distributor Name
-    Default: IT Services
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
@@ -27,12 +23,12 @@ Resources:
         config:
           ignore_checks:
             - E3002
+            - E3003
+            - W2001
     Properties:
       Name: !Ref ProductName
       Description: This product builds one Linux EC2 instance, either
         Amazon Linux or Ubuntu, with Jumpcloud integration.
-      Owner: !Ref 'PortfolioProvider'
-      Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
         - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:
@@ -41,7 +37,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
+          Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipool/products.yaml"
       ReplaceProvisioningArtifacts: true
   Associateec2linux:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation

--- a/ec2/sc-product-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-windows-jumpcloud.yaml
@@ -1,10 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Windows EC2 ServiceCatalog product with Jumpcloud integration.
 Parameters:
-  PortfolioProvider:
-    Type: String
-    Description: Owner and Distributor Name
-    Default: IT Services
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
@@ -27,12 +23,12 @@ Resources:
         config:
           ignore_checks:
             - E3002
+            - E3003
+            - W2001
     Properties:
       Name: !Ref ProductName
       Description: This product builds one Microsoft Windows EC2 instance with
         Jumpcloud integration.
-      Owner: !Ref 'PortfolioProvider'
-      Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
         - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:

--- a/ec2/sc-product-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-windows-jumpcloud.yaml
@@ -37,6 +37,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
+          # source: https://github.com/Sage-Bionetworks/admincentral-infra/blob/master/templates/cfn-snippets-bucket.yaml
           Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
       ReplaceProvisioningArtifacts: true
   Associateec2windows:

--- a/s3/sc-portfolio-s3-basic.yaml
+++ b/s3/sc-portfolio-s3-basic.yaml
@@ -4,16 +4,15 @@ Parameters:
   PortfolioProvider:
     Type: String
     Description: Provider Name
-    Default: IT Services
+    Default: Sage Bionetworks
   PorfolioName:
     Type: String
     Description: Portfolio Name
-    Default: Service Catalog S3 Reference Architecture
+    Default: S3 Portfolio
   PorfolioDescription:
     Type: String
     Description: Portfolio Description
-    Default: Service Catalog Portfolio that contains reference architecture products
-      for Amazon Simple Storage Service.
+    Default: Portfolio of S3 products
 Resources:
   SCS3portfolio:
     Type: AWS::ServiceCatalog::Portfolio

--- a/s3/sc-product-s3-private-enc.yaml
+++ b/s3/sc-product-s3-private-enc.yaml
@@ -1,10 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: S3 private encrypted ServiceCatalog product. (fdp-1p4da46rq)
 Parameters:
-  PortfolioProvider:
-    Type: String
-    Description: Owner and Distributor Name
-    Default: IT Services
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
@@ -27,12 +23,12 @@ Resources:
         config:
           ignore_checks:
             - E3002
+            - E3003
+            - W2001
     Properties:
       Name: !Ref ProductName
       Description: This product builds an AWS S3 bucket encrypted with private
         access accessible from any source.
-      Owner: !Ref 'PortfolioProvider'
-      Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
         - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:
@@ -41,7 +37,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
+          Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipool/products.yaml"
       ReplaceProvisioningArtifacts: true
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation

--- a/s3/sc-product-s3-synapse.yaml
+++ b/s3/sc-product-s3-synapse.yaml
@@ -1,10 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: S3 Synapse ServiceCatalog product.
 Parameters:
-  PortfolioProvider:
-    Type: String
-    Description: Owner and Distributor Name
-    Default: IT Services
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
@@ -27,12 +23,12 @@ Resources:
         config:
           ignore_checks:
             - E3002
+            - E3003
+            - W2001
     Properties:
       Name: !Ref ProductName
       Description: This product builds an AWS S3 bucket with private access
         for Synapse.
-      Owner: !Ref 'PortfolioProvider'
-      Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
         - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:
@@ -41,7 +37,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
+          Location: "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipool/products.yaml"
       ReplaceProvisioningArtifacts: true
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation

--- a/s3/sc-s3-encrypted-ra-v1.0.0.yaml
+++ b/s3/sc-s3-encrypted-ra-v1.0.0.yaml
@@ -1,7 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
-  Service Catalog S3 Reference Architecture: Private encrypted bucket
-  using AES256 with retention on object deletion.
+  Private encrypted S3 bucket using AES256 with retention on object deletion.
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
PR https://github.com/Sage-Bionetworks/admincentral-infra/pull/84
created a new snippet (products.yaml).  The new snippet adds
owner and Distributor properties.  Now we can use the products
snippet for all Sage products.