### PR TITLE
Output public IP address

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
@@ -426,6 +426,9 @@ Outputs:
     Value: !Ref 'LinuxInstance'
   LinuxInstancePrivateIpAddress:
     Value: !GetAtt 'LinuxInstance.PrivateIp'
+  LinuxInstancePublicIpAddress:
+    Condition: UsePublicSubnet
+    Value: !GetAtt LinuxInstance.PublicIp
   EC2InstanceType:
     Value: !Ref 'EC2InstanceType'
   IAMInstanceRole:

--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -433,6 +433,9 @@ Outputs:
     Value: !Ref 'LinuxInstance'
   LinuxInstancePrivateIpAddress:
     Value: !GetAtt 'LinuxInstance.PrivateIp'
+  LinuxInstancePublicIpAddress:
+    Condition: UsePublicSubnet
+    Value: !GetAtt LinuxInstance.PublicIp
   EC2InstanceType:
     Value: !Ref 'EC2InstanceType'
   IAMInstanceRole:

--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -419,6 +419,9 @@ Outputs:
     Value: !Ref 'LinuxInstance'
   LinuxInstancePrivateIpAddress:
     Value: !GetAtt 'LinuxInstance.PrivateIp'
+  LinuxInstancePublicIpAddress:
+    Condition: UsePublicSubnet
+    Value: !GetAtt LinuxInstance.PublicIp
   EC2InstanceType:
     Value: !Ref 'EC2InstanceType'
   IAMInstanceRole:


### PR DESCRIPTION
The EC2 products templates support placing instances in public subnets
however it neglects to provide the public IP info.  This will display
the public IP address to end users if they choose to provision into
a public subnet.