### PR TITLE
Standardize default product names

### DIFF
--- a/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -10,7 +10,7 @@ Parameters:
   ProductName:
     Type: String
     Description: Name of the product that will be visible to the end user
-    Default: 'Notebook Linux EC2 Instance with Jumpcloud Integration'
+    Default: 'EC2: Ubuntu Linux with Notebook Software'
   StackDatetime:
     Type: String
     Description: Last updated date and time of product

--- a/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -10,7 +10,7 @@ Parameters:
   ProductName:
     Type: String
     Description: Name of the product that will be visible to the end user
-    Default: 'Workflows Linux EC2 Instance with Jumpcloud Integration'
+    Default: 'EC2: Ubuntu Linux with Workflow Software'
   StackDatetime:
     Type: String
     Description: Last updated date and time of product

--- a/ec2/sc-product-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud.yaml
@@ -10,7 +10,7 @@ Parameters:
   ProductName:
     Type: String
     Description: Name of the product that will be visible to the end user
-    Default: 'EC2 Linux with Jumpcloud Integration'
+    Default: 'EC2: Linux'
   StackDatetime:
     Type: String
     Description: Last updated date and time of product

--- a/ec2/sc-product-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-windows-jumpcloud.yaml
@@ -10,7 +10,7 @@ Parameters:
   ProductName:
     Type: String
     Description: Name of the product that will be visible to the end user
-    Default: 'EC2 Windows with Jumpcloud Integration'
+    Default: 'EC2: Windows'
   StackDatetime:
     Type: String
     Description: Last updated date and time of product

--- a/s3/sc-product-s3-private-enc.yaml
+++ b/s3/sc-product-s3-private-enc.yaml
@@ -10,7 +10,7 @@ Parameters:
   ProductName:
     Type: String
     Description: Name of the product that will be visible to the end user
-    Default: 'S3 Private Encrypted Bucket'
+    Default: 'S3: Private Encrypted Bucket'
   StackDatetime:
     Type: String
     Description: Last updated date and time of product

--- a/s3/sc-product-s3-synapse.yaml
+++ b/s3/sc-product-s3-synapse.yaml
@@ -10,7 +10,7 @@ Parameters:
   ProductName:
     Type: String
     Description: Name of the product that will be visible to the end user
-    Default: 'S3 Synapse Bucket'
+    Default: 'S3: Synapse Bucket'
   StackDatetime:
     Type: String
     Description: Last updated date and time of product


### PR DESCRIPTION
Changed product names to something more standardized, removing "Jumpcloud" from all names.
