### PR TITLE
Add descriptions to template outputs, and add a new output for seeing…

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
@@ -369,18 +369,23 @@ Resources:
             'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-RoleId'
 Outputs:
   LinuxInstanceId:
+    Description: 'The ID of the EC2 instance'
     Value: !Ref 'LinuxInstance'
   LinuxInstancePrivateIpAddress:
+    Description: 'The IP Address of the EC2 instance'
     Value: !GetAtt 'LinuxInstance.PrivateIp'
   EC2InstanceType:
+    Description: 'The EC2 instance type'
     Value: !Ref 'EC2InstanceType'
-  IAMInstanceRole:
-    Value: !Ref 'InstanceRole'
-  IAMInstanceProfile:
-    Value: !Ref 'InstanceProfile'
   ConnectionInstructions:
+    Description: 'Guidelines on connecting to instances'
     Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"
   ConnectionURI:
+    Description: 'Starts a shell session in the AWS Console'
     Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${LinuxInstance}?region=${AWS::Region}"
   NotebookConnectionURI:
+    Description: 'Notebook server login page'
     Value: !Sub "http://${LinuxInstance.PrivateIp}:8787"
+  EC2ConsoleURI:
+    Description: 'Check your instance status with this link to the AWS Console'
+    Value: !Sub "https://console.aws.amazon.com/ec2/v2/home?region=${AWS::Region}#Instances:search=${LinuxInstance}"

--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -374,16 +374,17 @@ Resources:
             'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-RoleId'
 Outputs:
   LinuxInstanceId:
+    Description: 'The ID of the EC2 instance'
     Value: !Ref 'LinuxInstance'
   LinuxInstancePrivateIpAddress:
+    Description: 'The IP Address of the EC2 instance'
     Value: !GetAtt 'LinuxInstance.PrivateIp'
   EC2InstanceType:
+    Description: 'The EC2 instance type'
     Value: !Ref 'EC2InstanceType'
-  IAMInstanceRole:
-    Value: !Ref 'InstanceRole'
-  IAMInstanceProfile:
-    Value: !Ref 'InstanceProfile'
-  ConnectionInstructions:
-    Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"
   ConnectionURI:
+    Description: 'Starts a shell session in the AWS Console'
     Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${LinuxInstance}?region=${AWS::Region}"
+  EC2ConsoleURI:
+    Description: 'Check your instance status with this link to the AWS Console'
+    Value: !Sub "https://console.aws.amazon.com/ec2/v2/home?region=${AWS::Region}#Instances:search=${LinuxInstance}"

--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -362,16 +362,17 @@ Resources:
             'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-RoleId'
 Outputs:
   LinuxInstanceId:
+    Description: 'The ID of the EC2 instance'
     Value: !Ref 'LinuxInstance'
   LinuxInstancePrivateIpAddress:
+    Description: 'The IP Address of the EC2 instance'
     Value: !GetAtt 'LinuxInstance.PrivateIp'
   EC2InstanceType:
+    Description: 'The EC2 instance type'
     Value: !Ref 'EC2InstanceType'
-  IAMInstanceRole:
-    Value: !Ref 'InstanceRole'
-  IAMInstanceProfile:
-    Value: !Ref 'InstanceProfile'
-  ConnectionInstructions:
-    Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"
   ConnectionURI:
+    Description: 'Starts a shell session in the AWS Console'
     Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${LinuxInstance}?region=${AWS::Region}"
+  EC2ConsoleURI:
+    Description: 'Check your instance status with this link to the AWS Console'
+    Value: !Sub "https://console.aws.amazon.com/ec2/v2/home?region=${AWS::Region}#Instances:search=${LinuxInstance}"

--- a/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
@@ -244,16 +244,17 @@ Resources:
             'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-RoleId'
 Outputs:
   WindowsInstancePrivateIpAddress:
+    Description: 'The IP Address of the EC2 instance'
     Value: !GetAtt 'WindowsInstance.PrivateIp'
-  WindosInstanceAvailabilityZone:
-    Value: !GetAtt 'WindowsInstance.AvailabilityZone'
   WindowsInstanceId:
+    Description: 'The ID of the EC2 instance'
     Value: !Ref 'WindowsInstance'
   WindowsInstanceType:
+    Description: 'The EC2 instance type'
     Value: !Ref 'WindowsInstanceType'
-  IAMInstanceRole:
-    Value: !Ref 'InstanceRole'
-  IAMInstanceProfile:
-    Value: !Ref 'InstanceProfile'
   ConnectionInstructions:
+    Description: 'Guidelines on connecting to instances'
     Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"
+  EC2ConsoleURI:
+    Description: 'Check your instance status with this link to the AWS Console'
+    Value: !Sub "https://console.aws.amazon.com/ec2/v2/home?region=${AWS::Region}#Instances:search=${WindowsInstance}"

--- a/s3/sc-s3-encrypted-ra-v1.0.0.yaml
+++ b/s3/sc-s3-encrypted-ra-v1.0.0.yaml
@@ -52,8 +52,11 @@ Resources:
       ExtraPrincipalArns: !Ref S3UserARNs
 Outputs:
   BucketName:
+    Description: 'The name of the S3 Bucket'
     Value: !Ref 'S3Bucket'
   BucketARN:
+    Description: 'The ARN of the S3 Bucket'
     Value: !GetAtt 'S3Bucket.Arn'
   BucketUrl:
+    Description: 'View the S3 Bucket in the AWS Console'
     Value: !Sub 'https://console.aws.amazon.com/s3/home?region=${AWS::Region}&bucket=${S3Bucket}'

--- a/s3/sc-s3-synapse-ra-v1.0.0.yaml
+++ b/s3/sc-s3-synapse-ra-v1.0.0.yaml
@@ -89,8 +89,11 @@ Resources:
       BucketName: !Ref S3Bucket
 Outputs:
   BucketName:
+    Description: 'The name of the S3 Bucket'
     Value: !Ref 'S3Bucket'
   BucketARN:
+    Description: 'The ARN of the S3 Bucket'
     Value: !GetAtt 'S3Bucket.Arn'
   BucketUrl:
+    Description: 'View the S3 Bucket in the AWS Console'
     Value: !Sub 'https://console.aws.amazon.com/s3/home?region=${AWS::Region}&bucket=${S3Bucket}'


### PR DESCRIPTION
- Give descriptions to existing outputs
- Removed one output from the Windows product that is not in the other EC2 products
- Added an output to all EC2 products that links to their instance in the EC2 console, for checking the instance status
