### PR TITLE
[SC-39] Remove SCEnduserGroup

### DIFF
--- a/ec2/sc-portfolio-ec2.yaml
+++ b/ec2/sc-portfolio-ec2.yaml
@@ -27,13 +27,6 @@ Resources:
         'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-RoleArn'
       PortfolioId: !Ref 'SCEC2portfolio'
       PrincipalType: IAM
-  LinkEndusersGroup:
-    Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
-    Properties:
-      PrincipalARN: !ImportValue
-        'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-GroupArn'
-      PortfolioId: !Ref 'SCEC2portfolio'
-      PrincipalType: IAM
 Outputs:
   SCEC2portfolioId:
     Value: !Ref SCEC2portfolio

--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -7,8 +7,6 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
         - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
-        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
-        - arn:aws:iam::aws:policy/IAMReadOnlyAccess
         - arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess
         - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
         - !Ref SCEnduserExpandedPolicy

--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -6,9 +6,6 @@ Resources:
       GroupName: ServiceCatalogEndusers
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
-        - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
-        - arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess
-        - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
         - !Ref SCEnduserExpandedPolicy
         - !Ref CFNDenyGetTemplateSummaryPolicy
         - !Ref SCEnduserRemoteAccessPolicy

--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -1,15 +1,5 @@
 Description: "ServiceCatalog End User policy and group (fdp-1p4dlgcp7)"
 Resources:
-  SCEnduserGroup:
-    Type: AWS::IAM::Group
-    Properties:
-      GroupName: ServiceCatalogEndusers
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
-        - !Ref SCEnduserExpandedPolicy
-        - !Ref CFNDenyGetTemplateSummaryPolicy
-        - !Ref SCEnduserRemoteAccessPolicy
-      Path: /
   SCEnduserRole:
     Type: AWS::IAM::Role
     Properties:
@@ -87,14 +77,6 @@ Resources:
               - cloudformation:GetTemplateSummary
             Resource: "*"
 Outputs:
-  EndUserGroupArn:
-    Value: !GetAtt SCEnduserGroup.Arn
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceCatalogEndusers-GroupArn'
-  EndUserGroupName:
-    Value: !Ref SCEnduserGroup
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceCatalogEndusers-GroupName'
   EndUserRoleId:
     Value: !GetAtt SCEnduserRole.RoleId
     Export:

--- a/s3/sc-portfolio-s3-basic.yaml
+++ b/s3/sc-portfolio-s3-basic.yaml
@@ -27,13 +27,6 @@ Resources:
         'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-RoleArn'
       PortfolioId: !Ref 'SCS3portfolio'
       PrincipalType: IAM
-  LinkEndusersGroup:
-    Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
-    Properties:
-      PrincipalARN: !ImportValue
-        'Fn::Sub': '${AWS::Region}-sc-enduser-iam-ServiceCatalogEndusers-GroupArn'
-      PortfolioId: !Ref 'SCS3portfolio'
-      PrincipalType: IAM
 Outputs:
   SCS3portfolioId:
     Value: !Ref SCS3portfolio


### PR DESCRIPTION
The SCEnduserGroup was initially setup for IAM users to access the SC.
Now that we have users loging in thru synapse and assuming the
SCEnduserRole we no longer need SCEnduserGroup.

Note: deploying this PR requires that we first remove the `LinkEndusersGroup`
from the S3 and EC2 portfolios.