### PR TITLE
Deploy sc-<service>-* templates before product and portfolio templates

### DIFF
--- a/deploy-templates.sh
+++ b/deploy-templates.sh
@@ -14,5 +14,14 @@ aws s3 rm --recursive $S3_BUCKET_URL/
 DIRS=$(ls -d */)
 for dir in $DIRS
 do
-  aws s3 cp --recursive ${dir} $S3_BUCKET_URL/${dir}
+  product_templates=$(ls $dir | grep -E "sc-ec2|sc-s3")
+  for product_template in product_templates
+  do
+    aws s3 cp ${dir}/${product_template} $S3_BUCKET_URL/${dir}/${product_template}
+  done
+  non_product_templates=$(ls $dir | grep -Ev "sc-ec2|sc-s3")
+  for non_product_template in non_product_templates
+  do
+    aws s3 cp ${dir}/${non_product_template} $S3_BUCKET_URL/${dir}/${non_product_template}
+  done
 done


### PR DESCRIPTION
This is a proposed change to how templates are deployed to avoid splitting the templates between repositories.