### PR TITLE
Add cfn signals to EC2 products

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -296,9 +296,13 @@ Resources:
               group: root
           commands:
             01_enable_cfn-hup:
-              command: "/bin/systemctl enable cfn-hup.service"
+              command: !Sub |
+                /bin/systemctl enable cfn-hup.service ;\
+                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}'
             02_start_cfn-hup:
-              command: "/bin/systemctl start cfn-hup.service"
+              command: !Sub |
+                /bin/systemctl start cfn-hup.service ;\
+                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}'
         set_env_vars:
           files:
             /opt/sage/bin/make_env_vars_file.sh:
@@ -308,7 +312,9 @@ Resources:
               group: "root"
           commands:
             01_make_env_vars_file:
-              command: "/bin/bash /opt/sage/bin/make_env_vars_file.sh"
+              command: !Sub |
+                /bin/bash /opt/sage/bin/make_env_vars_file.sh ;\
+                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}'
               env:
                 AWS_REGION: !Ref AWS::Region
                 STACK_NAME: !Ref AWS::StackName
@@ -316,12 +322,12 @@ Resources:
         TagRootVolume:
           commands:
             01_tag_root_disk:
-              command: !Join
-                - ''
-                - - ". /opt/sage/bin/instance_env_vars.sh;"
-                  - "/usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID "
-                  - "--tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME "
-                  - "Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL"
+              command: !Sub |
+                . /opt/sage/bin/instance_env_vars.sh ;\
+                /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
+                  --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
+                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL ;\
+                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}'
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:
@@ -331,7 +337,9 @@ Resources:
               group: "root"
           commands:
             01_name_tag:
-              command: "/bin/bash /opt/sage/bin/apply_name_tag.sh"
+              command: !Sub |
+                /bin/bash /opt/sage/bin/apply_name_tag.sh ;\
+                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
         WriteApacheConf:
           files:
             /opt/sage/bin/apache_conf_rewrite.sh:
@@ -341,7 +349,9 @@ Resources:
               group: "root"
           commands:
             01_rewrite_apache_conf:
-              command: "/bin/bash /opt/sage/bin/apache_conf_rewrite.sh"
+              command: !Sub |
+                /bin/bash /opt/sage/bin/apache_conf_rewrite.sh ;\
+                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
     Properties:
       ImageId: !FindInMap [NotebookTypes, !Ref NotebookType, AMIID]
       InstanceType: !Ref 'EC2InstanceType'
@@ -373,6 +383,10 @@ Resources:
           Value: "yes"
         - Key: "PatchGroup"
           Value: "prod-default"
+    CreationPolicy:
+      ResourceSignal:
+        Count: 7 #Must equal the number of calls to cfn-signal during provisioning
+        Timeout: PT10M
 
   EC2TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup

--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -296,13 +296,9 @@ Resources:
               group: root
           commands:
             01_enable_cfn-hup:
-              command: !Sub |
-                /bin/systemctl enable cfn-hup.service ;\
-                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}'
+              command: "/bin/systemctl enable cfn-hup.service"
             02_start_cfn-hup:
-              command: !Sub |
-                /bin/systemctl start cfn-hup.service ;\
-                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}'
+              command: "/bin/systemctl start cfn-hup.service"
         set_env_vars:
           files:
             /opt/sage/bin/make_env_vars_file.sh:
@@ -312,9 +308,7 @@ Resources:
               group: "root"
           commands:
             01_make_env_vars_file:
-              command: !Sub |
-                /bin/bash /opt/sage/bin/make_env_vars_file.sh ;\
-                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}'
+              command: "/bin/bash /opt/sage/bin/make_env_vars_file.sh"
               env:
                 AWS_REGION: !Ref AWS::Region
                 STACK_NAME: !Ref AWS::StackName
@@ -326,8 +320,7 @@ Resources:
                 . /opt/sage/bin/instance_env_vars.sh ;\
                 /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
                   --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
-                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL ;\
-                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}'
+                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL 
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:
@@ -337,9 +330,7 @@ Resources:
               group: "root"
           commands:
             01_name_tag:
-              command: !Sub |
-                /bin/bash /opt/sage/bin/apply_name_tag.sh ;\
-                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
+              command: "/bin/bash /opt/sage/bin/apply_name_tag.sh"
         WriteApacheConf:
           files:
             /opt/sage/bin/apache_conf_rewrite.sh:
@@ -349,9 +340,7 @@ Resources:
               group: "root"
           commands:
             01_rewrite_apache_conf:
-              command: !Sub |
-                /bin/bash /opt/sage/bin/apache_conf_rewrite.sh ;\
-                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
+              command: "/bin/bash /opt/sage/bin/apache_conf_rewrite.sh "
     Properties:
       ImageId: !FindInMap [NotebookTypes, !Ref NotebookType, AMIID]
       InstanceType: !Ref 'EC2InstanceType'
@@ -385,7 +374,6 @@ Resources:
           Value: "prod-default"
     CreationPolicy:
       ResourceSignal:
-        Count: 7 #Must equal the number of calls to cfn-signal during provisioning
         Timeout: PT10M
 
   EC2TargetGroup:

--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -320,7 +320,7 @@ Resources:
                 . /opt/sage/bin/instance_env_vars.sh ;\
                 /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
                   --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
-                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL 
+                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:

--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -340,7 +340,7 @@ Resources:
               group: "root"
           commands:
             01_rewrite_apache_conf:
-              command: "/bin/bash /opt/sage/bin/apache_conf_rewrite.sh "
+              command: "/bin/bash /opt/sage/bin/apache_conf_rewrite.sh"
     Properties:
       ImageId: !FindInMap [NotebookTypes, !Ref NotebookType, AMIID]
       InstanceType: !Ref 'EC2InstanceType'
@@ -374,7 +374,7 @@ Resources:
           Value: "prod-default"
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT10M
+        Timeout: PT20M
 
   EC2TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup

--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -279,12 +279,11 @@ Resources:
         TagRootVolume:
           commands:
             01_tag_root_disk:
-              command: !Join
-                - ''
-                - - ". /opt/sage/bin/instance_env_vars.sh;"
-                  - "/usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID "
-                  - "--tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME "
-                  - "Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL"
+              command: !Sub |
+                . /opt/sage/bin/instance_env_vars.sh ;\
+                /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
+                  --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
+                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:

--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -329,6 +329,9 @@ Resources:
           Value: "yes"
         - Key: "PatchGroup"
           Value: "prod-default"
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT10M
 Outputs:
   LinuxInstanceId:
     Description: 'The ID of the EC2 instance'

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -275,13 +275,9 @@ Resources:
               group: root
           commands:
             01_enable_cfn-hup:
-              command: !Sub |
-                /bin/systemctl enable cfn-hup.service ;\
-                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
+              command: "/bin/systemctl enable cfn-hup.service"
             02_start_cfn-hup:
-              command: !Sub |
-                /bin/systemctl start cfn-hup.service ;\
-                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
+              command: "/bin/systemctl start cfn-hup.service"
         set_env_vars:
           files:
             /opt/sage/bin/make_env_vars_file.sh:
@@ -291,9 +287,7 @@ Resources:
               group: "root"
           commands:
             01_make_env_vars_file:
-              command: !Sub |
-                /bin/bash /opt/sage/bin/make_env_vars_file.sh ;\
-                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
+              command: "/bin/bash /opt/sage/bin/make_env_vars_file.sh"
               env:
                 AWS_REGION: !Ref AWS::Region
                 STACK_NAME: !Ref AWS::StackName
@@ -305,8 +299,7 @@ Resources:
                 . /opt/sage/bin/instance_env_vars.sh ;\
                 /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
                   --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
-                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL ;\
-                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}'
+                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL 
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:
@@ -316,9 +309,7 @@ Resources:
               group: "root"
           commands:
             01_name_tag:
-              command: !Sub |
-                /bin/bash /opt/sage/bin/apply_name_tag.sh ;\
-                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
+              command: "/bin/bash /opt/sage/bin/apply_name_tag.sh"
     Properties:
       ImageId: !FindInMap [LinuxDistributions, !Ref LinuxDistribution, AMIID]
       InstanceType: !Ref 'EC2InstanceType'
@@ -351,7 +342,6 @@ Resources:
           Value: "prod-default"
     CreationPolicy:
       ResourceSignal:
-        Count: 6 #Must equal the number of calls to cfn-signal during provisioning
         Timeout: PT10M
 Outputs:
   LinuxInstanceId:

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -275,9 +275,13 @@ Resources:
               group: root
           commands:
             01_enable_cfn-hup:
-              command: "/bin/systemctl enable cfn-hup.service"
+              command: !Sub |
+                /bin/systemctl enable cfn-hup.service ;\
+                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
             02_start_cfn-hup:
-              command: "/bin/systemctl start cfn-hup.service"
+              command: !Sub |
+                /bin/systemctl start cfn-hup.service ;\
+                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
         set_env_vars:
           files:
             /opt/sage/bin/make_env_vars_file.sh:
@@ -287,7 +291,9 @@ Resources:
               group: "root"
           commands:
             01_make_env_vars_file:
-              command: "/bin/bash /opt/sage/bin/make_env_vars_file.sh"
+              command: !Sub |
+                /bin/bash /opt/sage/bin/make_env_vars_file.sh ;\
+                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
               env:
                 AWS_REGION: !Ref AWS::Region
                 STACK_NAME: !Ref AWS::StackName
@@ -295,12 +301,12 @@ Resources:
         TagRootVolume:
           commands:
             01_tag_root_disk:
-              command: !Join
-                - ''
-                - - ". /opt/sage/bin/instance_env_vars.sh;"
-                  - "/usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID "
-                  - "--tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME "
-                  - "Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL"
+              command: !Sub |
+                . /opt/sage/bin/instance_env_vars.sh ;\
+                /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
+                  --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
+                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL ;\
+                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}'
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:
@@ -310,7 +316,9 @@ Resources:
               group: "root"
           commands:
             01_name_tag:
-              command: "/bin/bash /opt/sage/bin/apply_name_tag.sh"
+              command: !Sub |
+                /bin/bash /opt/sage/bin/apply_name_tag.sh ;\
+                /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
     Properties:
       ImageId: !FindInMap [LinuxDistributions, !Ref LinuxDistribution, AMIID]
       InstanceType: !Ref 'EC2InstanceType'
@@ -341,6 +349,10 @@ Resources:
           Value: "yes"
         - Key: "PatchGroup"
           Value: "prod-default"
+    CreationPolicy:
+      ResourceSignal:
+        Count: 6 #Must equal the number of calls to cfn-signal during provisioning
+        Timeout: PT10M
 Outputs:
   LinuxInstanceId:
     Description: 'The ID of the EC2 instance'

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -299,7 +299,7 @@ Resources:
                 . /opt/sage/bin/instance_env_vars.sh ;\
                 /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
                   --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
-                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL 
+                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -238,6 +238,9 @@ Resources:
           Value: "yes"
         - Key: "PatchGroup"
           Value: "prod-default"
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT10M
 Outputs:
   WindowsInstancePrivateIpAddress:
     Description: 'The IP Address of the EC2 instance'

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -240,7 +240,7 @@ Resources:
           Value: "prod-default"
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT10M
+        Timeout: PT20M
 Outputs:
   WindowsInstancePrivateIpAddress:
     Description: 'The IP Address of the EC2 instance'


### PR DESCRIPTION
This change adds a Cloudformation signal counter to common instance templates so that the 'complete' status is reflected in the provisioned product only when all commands in the instance metadata bootstrapping complete successfully. 

This solution works with all current product types.