### PR TITLE
[SC-226] Add ssm-user to docker group instead of jc user which no longer exists

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -297,7 +297,7 @@ Resources:
         add_docker_user:
           commands:
             01_add_jc_user_to_docker_group:
-              command: "gpasswd -a $(cat /opt/sage/jcusername) docker"
+              command: "gpasswd -a ssm-user docker"
     Properties:
       ImageId: "ami-0aa07b115676a7bb0"  # https://github.com/Sage-Bionetworks-IT/packer-workflows/releases/tag/v1.0.5
       InstanceType: !Ref 'EC2InstanceType'


### PR DESCRIPTION
Previously, we were adding the jumpcloud user to the docker group on the workflows instances. However, we removed all the jumpcloud bits but forgot to change this. The ubuntu user is already added to the docker group in the packer playbook; here, just adding the ssm-user as well, since that's the default user when logging in through the SSM shell.