### PR TITLE
Add the ssm-user so that it can be added to the docker group

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -219,8 +219,6 @@ Resources:
           SetTags:
             - TagRootVolume
             - TagInstance
-          SetupDocker:
-            - add_docker_user
         cfn_hup_service:
           files:
             /etc/cfn/cfn-hup.conf:
@@ -238,7 +236,7 @@ Resources:
                 [cfn-auto-reloader-hook]
                 triggers=post.update
                 path=Resources.LinuxInstance.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetTags,SetupDocker --region ${AWS::Region}
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetTags --region ${AWS::Region}
               mode: "000400"
               owner: root
               group: root
@@ -294,10 +292,6 @@ Resources:
           commands:
             01_name_tag:
               command: "/bin/bash /opt/sage/bin/apply_name_tag.sh"
-        add_docker_user:
-          commands:
-            01_add_jc_user_to_docker_group:
-              command: "gpasswd -a ssm-user docker"
     Properties:
       ImageId: "ami-0aa07b115676a7bb0"  # https://github.com/Sage-Bionetworks-IT/packer-workflows/releases/tag/v1.0.5
       InstanceType: !Ref 'EC2InstanceType'
@@ -317,7 +311,12 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetTags,SetupDocker --region ${AWS::Region}
+          # This temporary fix adds the ssm-user here -- adding in init config
+          # isn't working.
+          /usr/sbin/useradd -m ssm-user -G docker
+          /bin/echo "ssm-user ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/ssm-user
+          /bin/chmod 0440 /etc/sudoers.d/ssm-user
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetTags --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
       Tags:
         - Key: Name


### PR DESCRIPTION
This isn't what I would ideally like, but it works. 
- creates ssm-user
- adds to docker group
- adds ssm-user as sudoer

I've tested this a bit in scipooldev and it appears to work -- I can connect through the ssm browser session as the ssm-user, can sudo without being prompted for a password, and ssm-user is a member of docker.

I would prefer to be able to configure things about the ssm-user that the ssm agent will create on login, but could find no way to do that.

I am creating the user and setting it up directly in UserData because when I attempt to set it up through a cfn-init config set command, the command appears to succeed, but the user doesn't exist after the command, like something that happens in a subshell.

Reminder, I will be out on Monday -- if we want to fix the bug faster, please merge after approval.