### PR TITLE
re-route S3BucketTagger to SynapseTagger

### DIFF
--- a/s3/sc-s3-encrypted-ra.yaml
+++ b/s3/sc-s3-encrypted-ra.yaml
@@ -39,10 +39,10 @@ Resources:
               SSEAlgorithm: AES256
   S3BucketTagger:
     DependsOn: S3BucketPolicy
-    Type: Custom::S3BucketTagger
+    Type: Custom::SynapseTagger
     Properties:
       ServiceToken: !ImportValue
-        'Fn::Sub': '${AWS::Region}-cfn-cr-bucket-tagger-FunctionArn'
+        'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetBucketTagsFunctionArn'
       BucketName: !Ref S3Bucket
   S3BucketPolicy:
     Type: Custom::SCS3BucketPolicy

--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -85,10 +85,10 @@ Resources:
       Body: !Join [ ",", !Ref SynapseIDs ]
   S3BucketTagger:
     DependsOn: S3BucketPolicy
-    Type: Custom::S3BucketTagger
+    Type: Custom::SynapseTagger
     Properties:
       ServiceToken: !ImportValue
-        'Fn::Sub': '${AWS::Region}-cfn-cr-bucket-tagger-FunctionArn'
+        'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetBucketTagsFunctionArn'
       BucketName: !Ref S3Bucket
 Outputs:
   BucketName:


### PR DESCRIPTION
The single purpose cfn-cr-bucket-tagger[1] custom resources is
deprecated[2]. It is being replaced with the multi purpose
cfn-cr-synapse-tagger[3 lambda

[1] https://github.com/Sage-Bionetworks-IT/cfn-cr-bucket-tagger
[2] https://github.com/Sage-Bionetworks-IT/cfn-cr-bucket-tagger/pull/6
[3] https://github.com/Sage-Bionetworks-IT/cfn-cr-synapse-tagger

depends on Sage-Bionetworks/scipool-infra#185