### PR TITLE
[SC-190] use SynapseTagger to apply synapse tags to EC2s

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -409,7 +409,7 @@ Resources:
       TargetGroupArn: !Ref EC2TargetGroup
       ListenerArn: !ImportValue
         'Fn::Sub': '${AWS::Region}-alb-notebook-access-ALBListenerARN'
-  TagInsance:
+  TagInstance:
     DependsOn: "InstanceProfile"
     Type: Custom::SynapseTagger
     Properties:

--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -409,7 +409,13 @@ Resources:
       TargetGroupArn: !Ref EC2TargetGroup
       ListenerArn: !ImportValue
         'Fn::Sub': '${AWS::Region}-alb-notebook-access-ALBListenerARN'
-
+  TagInsance:
+    DependsOn: "InstanceProfile"
+    Type: Custom::SynapseTagger
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetInstanceTagsFunctionArn'
+      InstanceId: !Ref LinuxInstance
 Outputs:
   LinuxInstanceId:
     Description: 'The ID of the EC2 instance'

--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -330,6 +330,13 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Timeout: PT10M
+  TagInsance:
+    DependsOn: "InstanceProfile"
+    Type: Custom::SynapseTagger
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetInstanceTagsFunctionArn'
+      InstanceId: !Ref LinuxInstance
 Outputs:
   LinuxInstanceId:
     Description: 'The ID of the EC2 instance'

--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -330,7 +330,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Timeout: PT10M
-  TagInsance:
+  TagInstance:
     DependsOn: "InstanceProfile"
     Type: Custom::SynapseTagger
     Properties:

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -343,7 +343,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Timeout: PT10M
-  TagInsance:
+  TagInstance:
     DependsOn: "InstanceProfile"
     Type: Custom::SynapseTagger
     Properties:

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -343,6 +343,13 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Timeout: PT10M
+  TagInsance:
+    DependsOn: "InstanceProfile"
+    Type: Custom::SynapseTagger
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetInstanceTagsFunctionArn'
+      InstanceId: !Ref LinuxInstance
 Outputs:
   LinuxInstanceId:
     Description: 'The ID of the EC2 instance'

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -241,7 +241,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Timeout: PT20M
-  TagInsance:
+  TagInstance:
     DependsOn: "InstanceProfile"
     Type: Custom::SynapseTagger
     Properties:

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -241,6 +241,13 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Timeout: PT20M
+  TagInsance:
+    DependsOn: "InstanceProfile"
+    Type: Custom::SynapseTagger
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetInstanceTagsFunctionArn'
+      InstanceId: !Ref WindowsInstance
 Outputs:
   WindowsInstancePrivateIpAddress:
     Description: 'The IP Address of the EC2 instance'


### PR DESCRIPTION
Use the cfn-cr-synapse-tagger[1] custom resource to apply synapse
metadata[2] to EC2 instances as tags.

[1] https://github.com/Sage-Bionetworks-IT/cfn-cr-synapse-tagger
[2] https://docs.synapse.org/rest/org/sagebionetworks/repo/model/UserProfile.html

depends on Sage-Bionetworks-IT/cfn-cr-synapse-tagger#9 Sage-Bionetworks/scipool-infra#185