### PR TITLE
[SC-168] Remove apply_name_tag.sh script

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -255,7 +255,6 @@ Resources:
             - set_env_vars
           SetTags:
             - TagRootVolume
-            - TagInstance
           SetupApacheProxy:
             - WriteApacheConf
         cfn_hup_service:
@@ -321,16 +320,6 @@ Resources:
                 /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
                   --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
                   Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL
-        TagInstance:
-          files:
-            /opt/sage/bin/apply_name_tag.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.6/linux/opt/sage/bin/apply_name_tag.sh"
-              mode: "00744"
-              owner: "root"
-              group: "root"
-          commands:
-            01_name_tag:
-              command: "/bin/bash /opt/sage/bin/apply_name_tag.sh"
         WriteApacheConf:
           files:
             /opt/sage/bin/apache_conf_rewrite.sh:

--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -218,7 +218,6 @@ Resources:
             - set_env_vars
           SetTags:
             - TagRootVolume
-            - TagInstance
         cfn_hup_service:
           files:
             /etc/cfn/cfn-hup.conf:
@@ -282,16 +281,6 @@ Resources:
                 /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
                   --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
                   Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL
-        TagInstance:
-          files:
-            /opt/sage/bin/apply_name_tag.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.5/linux/opt/sage/bin/apply_name_tag.sh"
-              mode: "00744"
-              owner: "root"
-              group: "root"
-          commands:
-            01_name_tag:
-              command: "/bin/bash /opt/sage/bin/apply_name_tag.sh"
     Properties:
       ImageId: "ami-0aa07b115676a7bb0"  # https://github.com/Sage-Bionetworks-IT/packer-workflows/releases/tag/v1.0.5
       InstanceType: !Ref 'EC2InstanceType'

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -236,7 +236,6 @@ Resources:
             - set_env_vars
           SetTags:
             - TagRootVolume
-            - TagInstance
         cfn_hup_service:
           files:
             /etc/cfn/cfn-hup.conf:
@@ -300,16 +299,6 @@ Resources:
                 /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
                   --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
                   Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL
-        TagInstance:
-          files:
-            /opt/sage/bin/apply_name_tag.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.5/linux/opt/sage/bin/apply_name_tag.sh"
-              mode: "00744"
-              owner: "root"
-              group: "root"
-          commands:
-            01_name_tag:
-              command: "/bin/bash /opt/sage/bin/apply_name_tag.sh"
     Properties:
       ImageId: !FindInMap [LinuxDistributions, !Ref LinuxDistribution, AMIID]
       InstanceType: !Ref 'EC2InstanceType'

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -75,7 +75,6 @@ Resources:
             - set_env_vars
           SetTags:
             - tag_volume
-            - tag_instance
           SetupJumpcloud:
             - install_jc
             - config_jc
@@ -194,19 +193,6 @@ Resources:
                   - ' -Project $env:PROJECT'
                   - ' -OwnerEmail $env:OWNER_EMAIL'
                   - ' > C:\scripts\tag-instance-volume.log'
-        tag_instance:
-          files:
-            'c:\\scripts\\tag_instance.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.6/aws/tag_instance.ps1"
-              mode: "0664"
-          commands:
-            01_tag_instance:
-              command: !Join
-                - ''
-                - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
-                  - '. C:\scripts\instance_env_vars.ps1;'
-                  - 'Powershell.exe C:\scripts\tag_instance.ps1 '
-                  - ' > C:\scripts\tag-instance.log'
     Properties:
       ImageId: 'ami-0f38562b9d4de0dfe'         # amazon/Windows_Server-2019-English-Full-Base-2020.07.15
       InstanceType: !Ref 'WindowsInstanceType'


### PR DESCRIPTION
The functionality to apply product name tag and access role approved tag
has beeen moved to the Synapse tagger.  Renoving it from here.

depends on Sage-Bionetworks-IT/cfn-cr-synapse-tagger#13