### PR TITLE
[SC-168] Remove tag root volume script

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -254,7 +254,6 @@ Resources:
           SetEnv:
             - set_env_vars
           SetTags:
-            - TagRootVolume
             - TagInstance
           SetupApacheProxy:
             - WriteApacheConf
@@ -313,14 +312,6 @@ Resources:
                 AWS_REGION: !Ref AWS::Region
                 STACK_NAME: !Ref AWS::StackName
                 STACK_ID: !Ref AWS::StackId
-        TagRootVolume:
-          commands:
-            01_tag_root_disk:
-              command: !Sub |
-                . /opt/sage/bin/instance_env_vars.sh ;\
-                /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
-                  --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
-                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:

--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -217,7 +217,6 @@ Resources:
           SetEnv:
             - set_env_vars
           SetTags:
-            - TagRootVolume
             - TagInstance
         cfn_hup_service:
           files:
@@ -274,24 +273,6 @@ Resources:
                 AWS_REGION: !Ref AWS::Region
                 STACK_NAME: !Ref AWS::StackName
                 STACK_ID: !Ref AWS::StackId
-        TagRootVolume:
-          commands:
-            01_tag_root_disk:
-              command: !Sub |
-                . /opt/sage/bin/instance_env_vars.sh ;\
-                /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
-                  --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
-                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL
-        TagInstance:
-          files:
-            /opt/sage/bin/apply_name_tag.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.5/linux/opt/sage/bin/apply_name_tag.sh"
-              mode: "00744"
-              owner: "root"
-              group: "root"
-          commands:
-            01_name_tag:
-              command: "/bin/bash /opt/sage/bin/apply_name_tag.sh"
     Properties:
       ImageId: "ami-0aa07b115676a7bb0"  # https://github.com/Sage-Bionetworks-IT/packer-workflows/releases/tag/v1.0.5
       InstanceType: !Ref 'EC2InstanceType'

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -235,7 +235,6 @@ Resources:
           SetEnv:
             - set_env_vars
           SetTags:
-            - TagRootVolume
             - TagInstance
         cfn_hup_service:
           files:
@@ -292,14 +291,6 @@ Resources:
                 AWS_REGION: !Ref AWS::Region
                 STACK_NAME: !Ref AWS::StackName
                 STACK_ID: !Ref AWS::StackId
-        TagRootVolume:
-          commands:
-            01_tag_root_disk:
-              command: !Sub |
-                . /opt/sage/bin/instance_env_vars.sh ;\
-                /usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID \
-                  --tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME \
-                  Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL
         TagInstance:
           files:
             /opt/sage/bin/apply_name_tag.sh:

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -74,7 +74,6 @@ Resources:
           SetEnv:
             - set_env_vars
           SetTags:
-            - tag_volume
             - tag_instance
           SetupJumpcloud:
             - install_jc
@@ -174,26 +173,6 @@ Resources:
                   - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcSystemsGroupId"}}
                   - ' -OwnerEmail $env:OWNER_EMAIL'
                   - ' > C:\scripts\associate-jc-system.log'
-        tag_volume:
-          files:
-            "c:\\scripts\\tag-instance-volume.ps1":
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.6/aws/tag-instance-volume.ps1"
-              mode: "0664"
-          commands:
-            01_tag_instance_volume:
-              command: !Join
-                - ''
-                - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
-                  - '. C:\scripts\instance_env_vars.ps1;'
-                  - 'Powershell.exe C:\scripts\tag-instance-volume.ps1 '
-                  - ' -AwsRegion '
-                  - !Ref AWS::Region
-                  - ' -StackName '
-                  - !Ref AWS::StackName
-                  - ' -Department $env:DEPARTMENT'
-                  - ' -Project $env:PROJECT'
-                  - ' -OwnerEmail $env:OWNER_EMAIL'
-                  - ' > C:\scripts\tag-instance-volume.log'
         tag_instance:
           files:
             'c:\\scripts\\tag_instance.ps1':


### PR DESCRIPTION
The functionality to apply tags to EC2 attached volumes has been moved
to the Synapse tagger. Renoving it from here.

depends on Sage-Bionetworks-IT/cfn-cr-synapse-tagger#14