### PR TITLE
[SC-133] Remove VpcName input

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -18,17 +18,20 @@ Metadata:
         default: Disk Size
 
 Mappings:
-
   NotebookTypes:
     Rstudio:
       AMIID: "ami-051310d409a32a5aa"  # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v2.0.0
+  AccountToImportParams:
+    "465877038949":   # org-sagebase-scipooldev
+      PrivateSubnet: "us-east-1-cesspoolvpc-PrivateSubnet"
+      VpnSecurityGroup: "us-east-1-cesspoolvpc-VpnSecurityGroup"
+      VPCId: "us-east-1-cesspoolvpc-VPCId"
+    "237179673806":   # org-sagebase-scipoolprod
+      PrivateSubnet: "us-east-1-internalpoolvpc-PrivateSubnet"
+      VpnSecurityGroup: "us-east-1-internalpoolvpc-VpnSecurityGroup"
+      VPCId: "us-east-1-internalpoolvpc-VPCId"
 
 Parameters:
-
-  VpcName:
-    Type: String
-    Description: The VPC to put resources into
-    Default: 'internalpoolvpc'
 
   EC2InstanceType:
     AllowedValues:
@@ -225,7 +228,7 @@ Resources:
     Properties:
       GroupDescription: 'Add ingress to 443 from notebook connection ALB'
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VPCId]
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 443
@@ -345,9 +348,10 @@ Resources:
       ImageId: !FindInMap [NotebookTypes, !Ref NotebookType, AMIID]
       InstanceType: !Ref 'EC2InstanceType'
       SubnetId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", PrivateSubnet]
       SecurityGroupIds:
-        - 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-VpnSecurityGroup'
+        - !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
         - !Ref NotebookConnectSecurityGroup
       KeyName: 'scipool'
       BlockDeviceMappings:
@@ -395,7 +399,7 @@ Resources:
         Port: 443
       UnhealthyThresholdCount: 3
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VPCId]
       Tags:
       - Key: Name
         Value: !Sub 'TargetGroup-${LinuxInstance}'

--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -14,10 +14,6 @@ Metadata:
       VolumeSize:
         default: Disk Size
 Parameters:
-  VpcName:
-    Type: String
-    Description: The VPC to put resources into
-    Default: 'internalpoolvpc'
   EC2InstanceType:
     AllowedValues:
       - c4.large
@@ -174,6 +170,14 @@ Parameters:
     Default: 16
     MinValue: 16
     MaxValue: 2000
+Mappings:
+  AccountToImportParams:
+    "465877038949":   # org-sagebase-scipooldev
+      PrivateSubnet: "us-east-1-cesspoolvpc-PrivateSubnet"
+      VpnSecurityGroup: "us-east-1-cesspoolvpc-VpnSecurityGroup"
+    "237179673806":   # org-sagebase-scipoolprod
+      PrivateSubnet: "us-east-1-internalpoolvpc-PrivateSubnet"
+      VpnSecurityGroup: "us-east-1-internalpoolvpc-VpnSecurityGroup"
 Resources:
   InstanceRole:
     Type: AWS::IAM::Role
@@ -296,9 +300,10 @@ Resources:
       ImageId: "ami-0aa07b115676a7bb0"  # https://github.com/Sage-Bionetworks-IT/packer-workflows/releases/tag/v1.0.5
       InstanceType: !Ref 'EC2InstanceType'
       SubnetId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", PrivateSubnet]
       SecurityGroupIds:
-        - 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-VpnSecurityGroup'
+        - !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
       KeyName: 'scipool'
       BlockDeviceMappings:
         -

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -22,11 +22,14 @@ Mappings:
       AMIID: "ami-0b7906ab614596e7e"  # https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/tree/v1.0.9
     AmazonLinux:
       AMIID: "ami-0810a318c4b1243c5"  # https://github.com/Sage-Bionetworks-IT/packer-base-amazonlinux2/tree/v1.0.2
+  AccountToImportParams:
+    "465877038949":   # org-sagebase-scipooldev
+      PrivateSubnet: "us-east-1-cesspoolvpc-PrivateSubnet"
+      VpnSecurityGroup: "us-east-1-cesspoolvpc-VpnSecurityGroup"
+    "237179673806":   # org-sagebase-scipoolprod
+      PrivateSubnet: "us-east-1-internalpoolvpc-PrivateSubnet"
+      VpnSecurityGroup: "us-east-1-internalpoolvpc-VpnSecurityGroup"
 Parameters:
-  VpcName:
-    Type: String
-    Description: The VPC to put resources into
-    Default: 'internalpoolvpc'
   EC2InstanceType:
     AllowedValues:
       - c4.large
@@ -314,9 +317,10 @@ Resources:
       ImageId: !FindInMap [LinuxDistributions, !Ref LinuxDistribution, AMIID]
       InstanceType: !Ref 'EC2InstanceType'
       SubnetId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", PrivateSubnet]
       SecurityGroupIds:
-        - 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-VpnSecurityGroup'
+        - !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
       KeyName: 'scipool'
       BlockDeviceMappings:
         -

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -245,7 +245,7 @@ Resources:
           Value: "prod-default"
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT20M
+        Timeout: PT30M
   TagInstance:
     DependsOn: "InstanceProfile"
     Type: Custom::SynapseTagger

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -14,10 +14,6 @@ Metadata:
       VolumeSize:
         default: Disk Size
 Parameters:
-  VpcName:
-    Type: String
-    Description: The VPC to put resources into
-    Default: 'internalpoolvpc'
   WindowsInstanceType:
     AllowedValues:
       - t3.nano
@@ -35,6 +31,14 @@ Parameters:
     Default: 30
     MinValue: 10
     MaxValue: 2000
+Mappings:
+  AccountToImportParams:
+    "465877038949":   # org-sagebase-scipooldev
+      PrivateSubnet1: "us-east-1-cesspoolvpc-PrivateSubnet1"
+      VpnSecurityGroup: "us-east-1-cesspoolvpc-VpnSecurityGroup"
+    "237179673806":   # org-sagebase-scipoolprod
+      PrivateSubnet1: "us-east-1-internalpoolvpc-PrivateSubnet1"
+      VpnSecurityGroup: "us-east-1-internalpoolvpc-VpnSecurityGroup"
 Resources:
   InstanceRole:
     Type: AWS::IAM::Role
@@ -211,9 +215,10 @@ Resources:
       ImageId: 'ami-0f38562b9d4de0dfe'         # amazon/Windows_Server-2019-English-Full-Base-2020.07.15
       InstanceType: !Ref 'WindowsInstanceType'
       SubnetId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet1'
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", PrivateSubnet1]
       SecurityGroupIds:
-        - 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-VpnSecurityGroup'
+        - !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
       KeyName: 'scipool'
       IamInstanceProfile: !Ref 'InstanceProfile'
       BlockDeviceMappings:

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -212,7 +212,7 @@ Resources:
                   - 'Powershell.exe C:\scripts\tag_instance.ps1 '
                   - ' > C:\scripts\tag-instance.log'
     Properties:
-      ImageId: 'ami-0f38562b9d4de0dfe'         # amazon/Windows_Server-2019-English-Full-Base-2020.07.15
+      ImageId: 'ami-085ad2978eea00cab'         # amazon/Windows_Server-2019-English-Full-Base-2020.07.15
       InstanceType: !Ref 'WindowsInstanceType'
       SubnetId: !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", PrivateSubnet1]


### PR DESCRIPTION
This change removes the VpcName input parameter users see when
provisioning EC2s in the service catalog. We automatically set the
VPC specific parameters based on which account the EC2 is provisioned
in.