### PR TITLE
Revert "[SC-241] Fix EC2 tagging policy (#236)"

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -206,6 +206,12 @@ Resources:
     Properties:
       Path: /
       ManagedPolicyArns:
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-get-role-policy-ReadAssumedRoleInformationPolicy'
         - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore' #For maintenance tasks
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -255,6 +261,8 @@ Resources:
         configSets:
           SetupCfn:
             - cfn_hup_service
+          SetEnv:
+            - set_env_vars
           SetupApacheProxy:
             - WriteApacheConf
         cfn_hup_service:
@@ -274,7 +282,7 @@ Resources:
                 [cfn-auto-reloader-hook]
                 triggers=post.update
                 path=Resources.LinuxInstance.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetupApacheProxy --region ${AWS::Region}
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupApacheProxy --region ${AWS::Region}
               mode: "000400"
               owner: root
               group: root
@@ -298,6 +306,20 @@ Resources:
               command: "/bin/systemctl enable cfn-hup.service"
             02_start_cfn-hup:
               command: "/bin/systemctl start cfn-hup.service"
+        set_env_vars:
+          files:
+            /opt/sage/bin/make_env_vars_file.sh:
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.6/linux/opt/sage/bin/make_env_vars_file.sh"
+              mode: "00744"
+              owner: "root"
+              group: "root"
+          commands:
+            01_make_env_vars_file:
+              command: "/bin/bash /opt/sage/bin/make_env_vars_file.sh"
+              env:
+                AWS_REGION: !Ref AWS::Region
+                STACK_NAME: !Ref AWS::StackName
+                STACK_ID: !Ref AWS::StackId
         WriteApacheConf:
           files:
             /opt/sage/bin/apache_conf_rewrite.sh:
@@ -329,7 +351,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetupApacheProxy --region ${AWS::Region}
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupApacheProxy --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
       Tags:
         - Key: Name

--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -187,6 +187,12 @@ Resources:
     Properties:
       Path: /
       ManagedPolicyArns:
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-get-role-policy-ReadAssumedRoleInformationPolicy'
         - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore' #For maintenance tasks
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -216,6 +222,8 @@ Resources:
         configSets:
           SetupCfn:
             - cfn_hup_service
+          SetEnv:
+            - set_env_vars
         cfn_hup_service:
           files:
             /etc/cfn/cfn-hup.conf:
@@ -233,7 +241,7 @@ Resources:
                 [cfn-auto-reloader-hook]
                 triggers=post.update
                 path=Resources.LinuxInstance.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn --region ${AWS::Region}
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv --region ${AWS::Region}
               mode: "000400"
               owner: root
               group: root
@@ -257,6 +265,20 @@ Resources:
               command: "/bin/systemctl enable cfn-hup.service"
             02_start_cfn-hup:
               command: "/bin/systemctl start cfn-hup.service"
+        set_env_vars:
+          files:
+            /opt/sage/bin/make_env_vars_file.sh:
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.5/linux/opt/sage/bin/make_env_vars_file.sh"
+              mode: "00744"
+              owner: "root"
+              group: "root"
+          commands:
+            01_make_env_vars_file:
+              command: "/bin/bash /opt/sage/bin/make_env_vars_file.sh"
+              env:
+                AWS_REGION: !Ref AWS::Region
+                STACK_NAME: !Ref AWS::StackName
+                STACK_ID: !Ref AWS::StackId
     Properties:
       ImageId: "ami-02fb1df88e77ef400"  # https://github.com/Sage-Bionetworks-IT/packer-workflows/releases/tag/v1.0.6
       InstanceType: !Ref 'EC2InstanceType'
@@ -282,7 +304,7 @@ Resources:
           /usr/sbin/useradd -m ssm-user -G docker
           /bin/echo "ssm-user ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/ssm-user
           /bin/chmod 0440 /etc/sudoers.d/ssm-user
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn --region ${AWS::Region}
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
       Tags:
         - Key: Name

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -204,6 +204,12 @@ Resources:
     Properties:
       Path: /
       ManagedPolicyArns:
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-get-role-policy-ReadAssumedRoleInformationPolicy'
         - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -233,6 +239,8 @@ Resources:
         configSets:
           SetupCfn:
             - cfn_hup_service
+          SetEnv:
+            - set_env_vars
         cfn_hup_service:
           files:
             /etc/cfn/cfn-hup.conf:
@@ -250,7 +258,7 @@ Resources:
                 [cfn-auto-reloader-hook]
                 triggers=post.update
                 path=Resources.LinuxInstance.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn --region ${AWS::Region}
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv --region ${AWS::Region}
               mode: "000400"
               owner: root
               group: root
@@ -274,6 +282,20 @@ Resources:
               command: "/bin/systemctl enable cfn-hup.service"
             02_start_cfn-hup:
               command: "/bin/systemctl start cfn-hup.service"
+        set_env_vars:
+          files:
+            /opt/sage/bin/make_env_vars_file.sh:
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.5/linux/opt/sage/bin/make_env_vars_file.sh"
+              mode: "00744"
+              owner: "root"
+              group: "root"
+          commands:
+            01_make_env_vars_file:
+              command: "/bin/bash /opt/sage/bin/make_env_vars_file.sh"
+              env:
+                AWS_REGION: !Ref AWS::Region
+                STACK_NAME: !Ref AWS::StackName
+                STACK_ID: !Ref AWS::StackId
     Properties:
       ImageId: !FindInMap [LinuxDistributions, !Ref LinuxDistribution, AMIID]
       InstanceType: !Ref 'EC2InstanceType'
@@ -294,7 +316,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn --region ${AWS::Region}
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
       Tags:
         - Key: Name

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -48,6 +48,10 @@ Resources:
     Properties:
       Path: /
       ManagedPolicyArns:
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
         - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore' #For maintenance tasks
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -79,6 +83,8 @@ Resources:
             - cfn_hup_service
           SetupApps:
             - install_apps
+          SetEnv:
+            - set_env_vars
           SetupJumpcloud:
             - install_jc
             - config_jc
@@ -97,7 +103,7 @@ Resources:
                  [cfn-auto-reloader-hook]
                  triggers=post.update
                  path=Resources.WindowsInstance.Metadata.AWS::CloudFormation::Init
-                 action=cfn-init.exe -v --stack ${AWS::StackId} --resource WindowsInstance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetupJumpcloud
+                 action=cfn-init.exe -v --stack ${AWS::StackId} --resource WindowsInstance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetEnv,SetupJumpcloud
           services:
             windows:
               cfn-hup:
@@ -125,6 +131,18 @@ Resources:
               command: 'Powershell.exe C:\ProgramData\chocolatey\bin\choco install awscli --yes --no-progress --ignore-checksums'
             05_install_googlechrome:
               command: 'Powershell.exe C:\ProgramData\chocolatey\bin\choco install googlechrome --yes --no-progress --ignore-checksums'
+        set_env_vars:
+          files:
+            'c:\\scripts\\set_env_vars_file.ps1':
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.6/aws/set_env_vars_file.ps1"
+              mode: "0664"
+          commands:
+            01_set_env_vars:
+              command: !Join
+                - ''
+                - - 'Powershell.exe C:\scripts\set_env_vars_file.ps1 '
+                  - '-StackId '
+                  - !Ref AWS::StackId
         install_jc:
           files:
             'c:\scripts\install-ms-vc.ps1':
@@ -185,7 +203,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           <script>
-          cfn-init.exe -v --stack ${AWS::StackId} --resource WindowsInstance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetupJumpcloud
+          cfn-init.exe -v --stack ${AWS::StackId} --resource WindowsInstance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetEnv,SetupJumpcloud
           cfn-signal.exe -e %errorlevel% --stack ${AWS::StackId} --resource WindowsInstance --region ${AWS::Region}
           </script>
       Tags:


### PR DESCRIPTION
This reverts commit c2e6fe0085bf8423999fab87966b69a1c684ab2a.
This change breaks the EC2 notebook and windows products because those
products have dependencies on the script that sets env vars.

On windows the associate-jc-system.ps1 script assumes the SYNAPSE_USER_ID
environment variable has been set.

On notebook the packer-rstudio AMI's access.py script assumes a
Protected/AccessApprovedCaller tag to exist on the instance.