### PR TITLE
[IT-1006] Add transit gateway security to EC2s

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -338,6 +338,8 @@ Resources:
       SecurityGroupIds:
         - !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
+        - !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", TgwSecurityGroupId]
         - !Ref NotebookConnectSecurityGroup
       KeyName: 'scipool'
       BlockDeviceMappings:

--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -287,6 +287,8 @@ Resources:
       SecurityGroupIds:
         - !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
+        - !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", TgwSecurityGroupId]
       KeyName: 'scipool'
       BlockDeviceMappings:
         -

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -304,6 +304,8 @@ Resources:
       SecurityGroupIds:
         - !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
+        - !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", TgwSecurityGroupId]
       KeyName: 'scipool'
       BlockDeviceMappings:
         -

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -191,6 +191,8 @@ Resources:
       SecurityGroupIds:
         - !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
+        - !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", TgwSecurityGroupId]
       KeyName: 'scipool'
       IamInstanceProfile: !Ref 'InstanceProfile'
       BlockDeviceMappings:


### PR DESCRIPTION
We add the transit gateway security group to EC2s so we can access their
private IPs after logging into the AWS client VPN.

depends on Sage-Bionetworks/admincentral-infra#101 Sage-Bionetworks/scipool-infra#233