### PR TITLE
[SC-312] switches ownership of uploaded objects to be that of the bucket

### DIFF
--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -65,6 +65,9 @@ Resources:
             AllowedOrigins: ['*']
             AllowedMethods: [GET, POST, PUT, HEAD]
             MaxAge: 3000
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
   S3BucketPolicy:
     Type: Custom::SCS3BucketPolicy
     Properties:


### PR DESCRIPTION
restrict Put-Object calls to include bucket-owner-full-control
users using the AWS CLI must upload with `--acl bucket-owner-full-control`
to cause the ownership to change

depends on https://github.com/Sage-Bionetworks-IT/cfn-cr-sc-bucket-policy/pull/4