### PR TITLE
update reference to WriteToSSMPolicy (SC-260)

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -213,7 +213,7 @@ Resources:
           'Fn::Sub': '${AWS::Region}-get-role-policy-ReadAssumedRoleInformationPolicy'
         - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore' #For maintenance tasks
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-sc-product-ec2-linux-jumpcloud-notebook-write-to-ssm-policy-WriteToSSMPolicy'
+          'Fn::Sub': '${AWS::Region}-sc-product-ec2-linux-notebook-write-to-ssm-policy-WriteToSSMPolicy'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
was using an out of date reference that we didn't delete in the dev stack.
So the full integration was working in dev, but not in prod.