### PR TITLE
[SC-251] ec2 linux docker product

### DIFF
--- a/ec2/sc-ec2-linux-docker.yaml
+++ b/ec2/sc-ec2-linux-docker.yaml
@@ -23,9 +23,7 @@ Metadata:
 Mappings:
   AMIs:
     AmzonLinuxDocker:
-      AmiId: "ami-00976e4febdaf36c0"  # https://github.com/Sage-Bionetworks-IT/packer-amazonlinux-docker/tree/v1.0.0
-    UbuntuDocker:
-      AmiId: "ami-0b7906ab614596e7e"  # https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/tree/v1.0.9
+      AmiId: "ami-0559a96a9284c1223"  # https://github.com/Sage-Bionetworks-IT/packer-amazonlinux-docker/tree/v1.0.0
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'
@@ -189,15 +187,12 @@ Parameters:
     Default: AmzonLinuxDocker
     AllowedValues:
       - AmzonLinuxDocker
-      - UbuntuDocker
   VolumeSize:
     Description: The EC2 volume size (in GB)
     Type: Number
     Default: 16
     MinValue: 16
     MaxValue: 2000
-Conditions:
-  IsUbuntu: !Equals [!Ref AMI, 'UbuntuDocker']
 Resources:
   InstanceRole:
     Type: AWS::IAM::Role
@@ -302,7 +297,7 @@ Resources:
       SubnetId: !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", PrivateSubnet]
       BlockDeviceMappings:
-        - DeviceName: !If [IsUbuntu, "/dev/sda1", "/dev/xvda"]
+        - DeviceName: "/dev/xvda"
           Ebs:
             DeleteOnTermination: true
             VolumeSize: !Ref VolumeSize

--- a/ec2/sc-ec2-linux-docker.yaml
+++ b/ec2/sc-ec2-linux-docker.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Service Catalog: Linux EC2 Docker'
+Description: 'Service Catalog: EC2 Docker'
 Metadata:
   cfn-lint:
     config:
@@ -8,24 +8,24 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: Linux Instance Configuration
+          default: EC2 Instance Configuration
         Parameters:
           - EC2InstanceType
-          - LinuxDistribution
+          - AMI
           - VolumeSize
     ParameterLabels:
       EC2InstanceType:
         default: EC2 Instance Type
-      LinuxDistribution:
-        default: Linux Distribution
+      AMI:
+        default: Base Image
       VolumeSize:
         default: Disk Size
 Mappings:
-  LinuxDistributions:
-    Ubuntu:
-      AMIID: "ami-0b7906ab614596e7e"  # https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/tree/v1.0.9
-    AmazonLinux:
-      AMIID: "ami-0d029704654345ff4"  # test ami
+  AMIs:
+    AmzonLinuxDocker:
+      AmiId: "ami-00976e4febdaf36c0"  # https://github.com/Sage-Bionetworks-IT/packer-amazonlinux-docker/tree/v1.0.0
+    UbuntuDocker:
+      AmiId: "ami-0b7906ab614596e7e"  # https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/tree/v1.0.9
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'
@@ -183,21 +183,21 @@ Parameters:
     Default: t3.micro
     Description: Amazon EC2 Instance Type
     Type: String
-  LinuxDistribution:
+  AMI:
     Type: String
-    Description: Linux distribution to use for instance operation system
-    Default: AmazonLinux
+    Description: The base AMI for the instance
+    Default: AmzonLinuxDocker
     AllowedValues:
-      - AmazonLinux
-      - Ubuntu
+      - AmzonLinuxDocker
+      - UbuntuDocker
   VolumeSize:
     Description: The EC2 volume size (in GB)
     Type: Number
-    Default: 8
-    MinValue: 8
+    Default: 16
+    MinValue: 16
     MaxValue: 2000
 Conditions:
-  IsUbuntu: !Equals [!Ref LinuxDistribution, 'Ubuntu']
+  IsUbuntu: !Equals [!Ref AMI, 'UbuntuDocker']
 Resources:
   InstanceRole:
     Type: AWS::IAM::Role
@@ -227,7 +227,7 @@ Resources:
       Path: /
       Roles:
         - !Ref 'InstanceRole'
-  LinuxInstance:
+  EC2Instance:
     Type: AWS::EC2::Instance
     Metadata:
       cfn-lint:
@@ -257,8 +257,8 @@ Resources:
               content: !Sub |
                 [cfn-auto-reloader-hook]
                 triggers=post.update
-                path=Resources.LinuxInstance.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv --region ${AWS::Region}
+                path=Resources.EC2Instance.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource EC2Instance --configsets SetupCfn,SetEnv --region ${AWS::Region}
               mode: "000400"
               owner: root
               group: root
@@ -297,17 +297,12 @@ Resources:
                 STACK_NAME: !Ref AWS::StackName
                 STACK_ID: !Ref AWS::StackId
     Properties:
-      ImageId: !FindInMap [LinuxDistributions, !Ref LinuxDistribution, AMIID]
+      ImageId: !FindInMap [AMIs, !Ref AMI, AmiId]
       InstanceType: !Ref 'EC2InstanceType'
       SubnetId: !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", PrivateSubnet]
-      SecurityGroupIds:
-        - !ImportValue
-          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
-      KeyName: 'scipool'
       BlockDeviceMappings:
-        -
-          DeviceName: !If [IsUbuntu, "/dev/sda1", "/dev/xvda"]
+        - DeviceName: !If [IsUbuntu, "/dev/sda1", "/dev/xvda"]
           Ebs:
             DeleteOnTermination: true
             VolumeSize: !Ref VolumeSize
@@ -316,8 +311,8 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv --region ${AWS::Region}
-          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource EC2Instance --configsets SetupCfn,SetEnv --region ${AWS::Region}
+          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource EC2Instance --region ${AWS::Region}
       Tags:
         - Key: Name
           Value: !Ref 'AWS::StackName'
@@ -336,20 +331,20 @@ Resources:
     Properties:
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetInstanceTagsFunctionArn'
-      InstanceId: !Ref LinuxInstance
+      InstanceId: !Ref EC2Instance
 Outputs:
-  LinuxInstanceId:
+  EC2InstanceId:
     Description: 'The ID of the EC2 instance'
-    Value: !Ref 'LinuxInstance'
-  LinuxInstancePrivateIpAddress:
+    Value: !Ref 'EC2Instance'
+  EC2InstancePrivateIpAddress:
     Description: 'The IP Address of the EC2 instance'
-    Value: !GetAtt 'LinuxInstance.PrivateIp'
+    Value: !GetAtt 'EC2Instance.PrivateIp'
   EC2InstanceType:
     Description: 'The EC2 instance type'
     Value: !Ref 'EC2InstanceType'
   ConnectionURI:
     Description: 'Starts a shell session in the AWS Console'
-    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${LinuxInstance}?region=${AWS::Region}"
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${EC2Instance}?region=${AWS::Region}"
   EC2ConsoleURI:
     Description: 'Check your instance status with this link to the AWS Console'
-    Value: !Sub "https://console.aws.amazon.com/ec2/v2/home?region=${AWS::Region}#Instances:search=${LinuxInstance}"
+    Value: !Sub "https://console.aws.amazon.com/ec2/v2/home?region=${AWS::Region}#Instances:search=${EC2Instance}"

--- a/ec2/sc-ec2-linux-docker.yaml
+++ b/ec2/sc-ec2-linux-docker.yaml
@@ -22,7 +22,7 @@ Metadata:
         default: Disk Size
 Mappings:
   AMIs:
-    AmzonLinuxDocker:
+    AmazonLinuxDocker:
       AmiId: "ami-0559a96a9284c1223"  # https://github.com/Sage-Bionetworks-IT/packer-amazonlinux-docker/tree/v1.0.0
   AccountToImportParams:
     'Fn::Transform':
@@ -184,9 +184,9 @@ Parameters:
   AMI:
     Type: String
     Description: The base AMI for the instance
-    Default: AmzonLinuxDocker
+    Default: AmazonLinuxDocker
     AllowedValues:
-      - AmzonLinuxDocker
+      - AmazonLinuxDocker
   VolumeSize:
     Description: The EC2 volume size (in GB)
     Type: Number

--- a/ec2/sc-ec2-linux-docker.yaml
+++ b/ec2/sc-ec2-linux-docker.yaml
@@ -1,0 +1,355 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Service Catalog: Linux EC2 Docker'
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E7001
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Linux Instance Configuration
+        Parameters:
+          - EC2InstanceType
+          - LinuxDistribution
+          - VolumeSize
+    ParameterLabels:
+      EC2InstanceType:
+        default: EC2 Instance Type
+      LinuxDistribution:
+        default: Linux Distribution
+      VolumeSize:
+        default: Disk Size
+Mappings:
+  LinuxDistributions:
+    Ubuntu:
+      AMIID: "ami-0b7906ab614596e7e"  # https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/tree/v1.0.9
+    AmazonLinux:
+      AMIID: "ami-0d029704654345ff4"  # test ami
+  AccountToImportParams:
+    'Fn::Transform':
+      Name: 'AWS::Include'
+      Parameters:
+        # include is @ https://github.com/Sage-Bionetworks/admincentral-infra/blob/master/templates/cfn-service-catalog-snippets.yaml
+        Location: s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipool-sc-lib-infra/ScAccountToExportMappping.yaml
+Parameters:
+  EC2InstanceType:
+    AllowedValues:
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+      - c5.9xlarge
+      - c5.12xlarge
+      - c5.18xlarge
+      - c5.24xlarge
+      - c5d.large
+      - c5d.xlarge
+      - c5d.2xlarge
+      - c5d.4xlarge
+      - c5d.9xlarge
+      - c5d.12xlarge
+      - c5d.18xlarge
+      - c5d.24xlarge
+      - c5n.large
+      - c5n.xlarge
+      - c5n.2xlarge
+      - c5n.4xlarge
+      - c5n.9xlarge
+      - c5n.18xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - m5.large
+      - m5.xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+      - m5.8xlarge
+      - m5.12xlarge
+      - m5.16xlarge
+      - m5.24xlarge
+      - m5a.large
+      - m5a.xlarge
+      - m5a.2xlarge
+      - m5a.4xlarge
+      - m5a.8xlarge
+      - m5a.12xlarge
+      - m5a.16xlarge
+      - m5a.24xlarge
+      - m5ad.large
+      - m5ad.xlarge
+      - m5ad.2xlarge
+      - m5ad.4xlarge
+      - m5ad.12xlarge
+      - m5ad.24xlarge
+      - m5d.large
+      - m5d.xlarge
+      - m5d.2xlarge
+      - m5d.4xlarge
+      - m5d.8xlarge
+      - m5d.12xlarge
+      - m5d.16xlarge
+      - m5d.24xlarge
+      - m5dn.large
+      - m5dn.xlarge
+      - m5dn.2xlarge
+      - m5dn.4xlarge
+      - m5dn.8xlarge
+      - m5dn.12xlarge
+      - m5dn.16xlarge
+      - m5dn.24xlarge
+      - m5n.large
+      - m5n.xlarge
+      - m5n.2xlarge
+      - m5n.4xlarge
+      - m5n.8xlarge
+      - m5n.12xlarge
+      - m5n.16xlarge
+      - m5n.24xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - r5.large
+      - r5.xlarge
+      - r5.2xlarge
+      - r5.4xlarge
+      - r5.8xlarge
+      - r5.12xlarge
+      - r5.16xlarge
+      - r5.24xlarge
+      - r5a.large
+      - r5a.xlarge
+      - r5a.2xlarge
+      - r5a.4xlarge
+      - r5a.8xlarge
+      - r5a.12xlarge
+      - r5a.16xlarge
+      - r5a.24xlarge
+      - r5ad.large
+      - r5ad.xlarge
+      - r5ad.2xlarge
+      - r5ad.4xlarge
+      - r5ad.12xlarge
+      - r5ad.24xlarge
+      - r5d.large
+      - r5d.xlarge
+      - r5d.2xlarge
+      - r5d.4xlarge
+      - r5d.8xlarge
+      - r5d.12xlarge
+      - r5d.16xlarge
+      - r5d.24xlarge
+      - r5dn.large
+      - r5dn.xlarge
+      - r5dn.2xlarge
+      - r5dn.4xlarge
+      - r5dn.8xlarge
+      - r5dn.12xlarge
+      - r5dn.16xlarge
+      - r5dn.24xlarge
+      - r5n.large
+      - r5n.xlarge
+      - r5n.2xlarge
+      - r5n.4xlarge
+      - r5n.8xlarge
+      - r5n.12xlarge
+      - r5n.16xlarge
+      - r5n.24xlarge
+      - t3.nano
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
+      - t3a.nano
+      - t3a.micro
+      - t3a.small
+      - t3a.medium
+      - t3a.large
+      - t3a.xlarge
+      - t3a.2xlarge
+    Default: t3.micro
+    Description: Amazon EC2 Instance Type
+    Type: String
+  LinuxDistribution:
+    Type: String
+    Description: Linux distribution to use for instance operation system
+    Default: AmazonLinux
+    AllowedValues:
+      - AmazonLinux
+      - Ubuntu
+  VolumeSize:
+    Description: The EC2 volume size (in GB)
+    Type: Number
+    Default: 8
+    MinValue: 8
+    MaxValue: 2000
+Conditions:
+  IsUbuntu: !Equals [!Ref LinuxDistribution, 'Ubuntu']
+Resources:
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      ManagedPolicyArns:
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-get-role-policy-ReadAssumedRoleInformationPolicy'
+        - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+                - ssm.amazonaws.com #For maintenance service
+            Action:
+              - sts:AssumeRole
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+        - !Ref 'InstanceRole'
+  LinuxInstance:
+    Type: AWS::EC2::Instance
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1022
+            - W1011
+      'AWS::CloudFormation::Init':
+        configSets:
+          SetupCfn:
+            - cfn_hup_service
+          SetEnv:
+            - set_env_vars
+        cfn_hup_service:
+          files:
+            /etc/cfn/cfn-hup.conf:
+              content: !Sub |
+                [main]
+                stack=${AWS::StackId}
+                region=${AWS::Region}
+                verbose=true
+                interval=5
+              mode: "000400"
+              owner: root
+              group: root
+            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
+              content: !Sub |
+                [cfn-auto-reloader-hook]
+                triggers=post.update
+                path=Resources.LinuxInstance.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv --region ${AWS::Region}
+              mode: "000400"
+              owner: root
+              group: root
+            /lib/systemd/system/cfn-hup.service:
+              content: |
+                [Unit]
+                Description=cfn-hup daemon
+
+                [Service]
+                Type=simple
+                ExecStart=/opt/aws/bin/cfn-hup
+                Restart=always
+
+                [Install]
+                WantedBy=multi-user.target
+              mode: "000400"
+              owner: root
+              group: root
+          commands:
+            01_enable_cfn-hup:
+              command: "/bin/systemctl enable cfn-hup.service"
+            02_start_cfn-hup:
+              command: "/bin/systemctl start cfn-hup.service"
+        set_env_vars:
+          files:
+            /opt/sage/bin/make_env_vars_file.sh:
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v1.0.5/linux/opt/sage/bin/make_env_vars_file.sh"
+              mode: "00744"
+              owner: "root"
+              group: "root"
+          commands:
+            01_make_env_vars_file:
+              command: "/bin/bash /opt/sage/bin/make_env_vars_file.sh"
+              env:
+                AWS_REGION: !Ref AWS::Region
+                STACK_NAME: !Ref AWS::StackName
+                STACK_ID: !Ref AWS::StackId
+    Properties:
+      ImageId: !FindInMap [LinuxDistributions, !Ref LinuxDistribution, AMIID]
+      InstanceType: !Ref 'EC2InstanceType'
+      SubnetId: !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", PrivateSubnet]
+      SecurityGroupIds:
+        - !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
+      KeyName: 'scipool'
+      BlockDeviceMappings:
+        -
+          DeviceName: !If [IsUbuntu, "/dev/sda1", "/dev/xvda"]
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: !Ref VolumeSize
+            Encrypted: true
+      IamInstanceProfile: !Ref 'InstanceProfile'
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv --region ${AWS::Region}
+          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
+      Tags:
+        - Key: Name
+          Value: !Ref 'AWS::StackName'
+        - Key: Description
+          Value: !Sub "Service Catalog instance created by ${AWS::StackName}"
+        - Key: "ManagedInstanceMaintenanceTarget"
+          Value: "yes"
+        - Key: "PatchGroup"
+          Value: "prod-default"
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT10M
+  TagInstance:
+    DependsOn: "InstanceProfile"
+    Type: Custom::SynapseTagger
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetInstanceTagsFunctionArn'
+      InstanceId: !Ref LinuxInstance
+Outputs:
+  LinuxInstanceId:
+    Description: 'The ID of the EC2 instance'
+    Value: !Ref 'LinuxInstance'
+  LinuxInstancePrivateIpAddress:
+    Description: 'The IP Address of the EC2 instance'
+    Value: !GetAtt 'LinuxInstance.PrivateIp'
+  EC2InstanceType:
+    Description: 'The EC2 instance type'
+    Value: !Ref 'EC2InstanceType'
+  ConnectionURI:
+    Description: 'Starts a shell session in the AWS Console'
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${LinuxInstance}?region=${AWS::Region}"
+  EC2ConsoleURI:
+    Description: 'Check your instance status with this link to the AWS Console'
+    Value: !Sub "https://console.aws.amazon.com/ec2/v2/home?region=${AWS::Region}#Instances:search=${LinuxInstance}"


### PR DESCRIPTION
A template for the service catalog to provision a linux EC2 with
docker.  Docker is installed into the packer-amazonlinux-docker AMI[1].
This template sets up policies to allow authorized users to access the
instance using the AWS Systems Manager (AWS SSM). 

[1] https://github.com/Sage-Bionetworks-IT/packer-amazonlinux-docker/tree/v1.0.0