### PR TITLE
Increase disk size limit for SC workflows product

### DIFF
--- a/ec2/sc-ec2-linux-docker.yaml
+++ b/ec2/sc-ec2-linux-docker.yaml
@@ -192,7 +192,7 @@ Parameters:
     Type: Number
     Default: 16
     MinValue: 16
-    MaxValue: 2000
+    MaxValue: 5000
 Resources:
   InstanceRole:
     Type: AWS::IAM::Role

--- a/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows.yaml
@@ -173,7 +173,7 @@ Parameters:
     Type: Number
     Default: 16
     MinValue: 16
-    MaxValue: 2000
+    MaxValue: 5000
 Mappings:
   AccountToImportParams:
     'Fn::Transform':


### PR DESCRIPTION
Depending on the dataset size, 2 TB is limiting given the number of large intermediate files that get generated. I propose increasing the limit to 5 TB (just for the workflows product) to give more breathing room. I need this in case NF Tower isn't set up in time to meet deadlines for processing data in the imCORE project. 

I believe once this PR is merged, a new version of this repository will need to be minted and this [file](https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/sceptre/scipool/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml#L18) will need to be changed. 