### PR TITLE
SC-318 updating R-Studio product to use new AMI

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -24,7 +24,7 @@ Metadata:
 Mappings:
   NotebookTypes:
     Rstudio:
-      AMIID: "ami-0c0f49c0711209967" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v2.1.1
+      AMIID: "ami-0fa2167c265c7ceae" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v2.1.2
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'


### PR DESCRIPTION
 Updating R-Studio product (v 2.1.2 of packer-rstudio) to use new AMI.   As per [SC-318](https://sagebionetworks.jira.com/browse/SC-318), this changes `/etc/security/limits.conf` to allow more concurrent open files.
