### PR TITLE
make sure bucket policy depends on bucket

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,4 +1,5 @@
 ignore_checks:
 - W1020
 - W3005
+- W3011
 - E1022

--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,3 +1,4 @@
 ignore_checks:
 - W1020
+- W3005
 - E1022

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,11 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.1
+    rev: v1.26.3
     hooks:
     -   id: yamllint
 -   repo: https://github.com/aws-cloudformation/cfn-python-lint
-    rev: v0.51.0
+    rev: v0.54.1
     hooks:
     -   id: cfn-python-lint
         files: .*/.*\.(json|yml|yaml)$

--- a/s3/sc-s3-encrypted-ra.yaml
+++ b/s3/sc-s3-encrypted-ra.yaml
@@ -57,6 +57,7 @@ Resources:
         'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetBucketTagsFunctionArn'
       BucketName: !Ref S3Bucket
   S3BucketPolicy:
+    DependsOn: S3Bucket
     Type: Custom::SCS3BucketPolicy
     Properties:
       ServiceToken: !ImportValue

--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -69,6 +69,7 @@ Resources:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred
   S3BucketPolicy:
+    DependsOn: S3Bucket
     Type: Custom::SCS3BucketPolicy
     Properties:
       ServiceToken: !ImportValue

--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -52,6 +52,8 @@ Conditions:
 Resources:
   S3Bucket:
     Type: "AWS::S3::Bucket"
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
       BucketEncryption:


### PR DESCRIPTION
A bucket delete may fail due to having existing data in the bucket.
When a failure occurs the bucket will remain however the  policy for it
may get removed.  This will cause a state where users will no longer
have access to the bucket.

This change makes sure that the policy deletion only happens after a
bucket has been delete.
