### PR TITLE
[SC-326] Retain bucket on SC product termination

### DIFF
--- a/s3/sc-s3-encrypted-ra.yaml
+++ b/s3/sc-s3-encrypted-ra.yaml
@@ -42,6 +42,8 @@ Conditions:
 Resources:
   S3Bucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
       AccessControl: Private

--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -52,6 +52,8 @@ Conditions:
 Resources:
   S3Bucket:
     Type: "AWS::S3::Bucket"
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
       BucketEncryption:


### PR DESCRIPTION
A bucket delete may fail due to having existing data in the bucket.
When a failure occurs the bucket will remain and SC will report that
the product is in a `Tainted` state.  When this occurs users cannot update
or terminate the product again which means they are stuck requiring
an AWS admin to help resolve the situation.

This change will make cloudformation ignore deleting the bucket.
When a user terminates the SC product the policy on the bucket
and the SC product is removed however the bucket itself is retained.
CFN doesn't even try to remove the bucket so it won't ever get into
the `tainted` state.  The bucket stays around and the policy is
removed so nobody has access to the bucket after an SC termination.

The effect is that the SC user thinks that the bucket has been deleted
however the bucket with all it's data is still around.  It's basically like the
data has been archived and requires admin intervention to allow access
again.