### PR TITLE
[SC-363]  Enable S3 intelligent tierring on buckets

### DIFF
--- a/s3/sc-s3-encrypted-ra.yaml
+++ b/s3/sc-s3-encrypted-ra.yaml
@@ -51,6 +51,14 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: IntelligentTieringRule
+            Prefix: IntTier
+            Status: Enabled
+            Transitions:
+              - TransitionInDays: 1
+                StorageClass: INTELLIGENT_TIERING
   S3BucketTagger:
     DependsOn: S3BucketPolicy
     Type: Custom::SynapseTagger

--- a/s3/sc-s3-encrypted-ra.yaml
+++ b/s3/sc-s3-encrypted-ra.yaml
@@ -53,8 +53,7 @@ Resources:
               SSEAlgorithm: AES256
       LifecycleConfiguration:
         Rules:
-          - Id: IntelligentTieringRule
-            Prefix: IntTier
+          - Id: IntelligentTieringClassTransitionRule
             Status: Enabled
             Transitions:
               - TransitionInDays: 1

--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -70,6 +70,14 @@ Resources:
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred
+      LifecycleConfiguration:
+        Rules:
+          - Id: IntelligentTieringRule
+            Prefix: IntTier
+            Status: Enabled
+            Transitions:
+              - TransitionInDays: 1
+                StorageClass: INTELLIGENT_TIERING
   S3BucketPolicy:
     Type: Custom::SCS3BucketPolicy
     Properties:

--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -72,8 +72,7 @@ Resources:
           - ObjectOwnership: BucketOwnerPreferred
       LifecycleConfiguration:
         Rules:
-          - Id: IntelligentTieringRule
-            Prefix: IntTier
+          - Id: IntelligentTieringClassTransitionRule
             Status: Enabled
             Transitions:
               - TransitionInDays: 1


### PR DESCRIPTION
We SC users provision buckets they use it for a variety of different
things.  We don't really know their usage patters ahead of time.  They
can upload files and leave them around for a long time which can be
expensive.  Enabling intelligent tiering on their buckets may help us
reduce S3 storage costs.  Well, this is what @marcomarasca says anyways.
