### PR TITLE
SC-45 remove arbitrary Role ARN parameter

### DIFF
--- a/s3/sc-s3-encrypted-ra.yaml
+++ b/s3/sc-s3-encrypted-ra.yaml
@@ -11,17 +11,8 @@ Metadata:
       - Label:
           default: S3 Bucket Policy Configuration
         Parameters:
-          - S3UserARNs
           - RestrictSameRegionDownload
 Parameters:
-  S3UserARNs:
-    Type: CommaDelimitedList
-    Description: >-
-      (Optional) User ARNs allowed to access S3 Bucket,
-      in addition to provisioning user
-    ConstraintDescription: >-
-      List of ARNs separated by commas (e.g.
-      arn:aws:iam::011223344556:user/jdoe,arn:aws:iam::544332211006:user/rjones)
   BucketName:
     Type: String
     Description: (Optional) Name of the created bucket.
@@ -71,7 +62,6 @@ Resources:
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-bucket-policy-FunctionArn'
       BucketName: !Ref S3Bucket
-      ExtraPrincipalArns: !Ref S3UserARNs
 
   SameRegionDownloadRestriction:
     DependsOn: S3BucketPolicy

--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -14,7 +14,6 @@ Metadata:
           default: S3 Bucket Policy Configuration
         Parameters:
           - SynapseIDs
-          - S3UserARNs
           - RestrictSameRegionDownload
 Parameters:
   SynapseIDs:
@@ -24,14 +23,6 @@ Parameters:
     ConstraintDescription: >-
       List of Synapse user or team IDs separated by commas
       (i.e. 1111111, 2222222)
-  S3UserARNs:
-    Type: CommaDelimitedList
-    Description: >-
-      (Optional) User ARNs allowed to access S3 Bucket,
-      in addition to provisioning user
-    ConstraintDescription: >-
-      List of ARNs separated by commas (e.g.
-      arn:aws:iam::011223344556:user/jdoe,arn:aws:iam::544332211006:user/rjones)
   BucketName:
     Type: String
     Description: (Optional) Name of the created bucket.
@@ -83,14 +74,7 @@ Resources:
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-bucket-policy-FunctionArn'
       BucketName: !Ref S3Bucket
-      ExtraPrincipalArns: !Split
-        - ","
-        - !Join
-            - ","
-            - - "arn:aws:iam::325565585839:root"
-              - !Join
-                  - ","
-                  - !Ref "S3UserARNs"
+      ExtraPrincipalArns: "arn:aws:iam::325565585839:root"
   # Add owner file to the synapse bucket, requires the cloudformation S3 objects macro
   # https://github.com/Sage-Bionetworks-IT/cfn-s3objects-macro
   SynapseOwnerFile:


### PR DESCRIPTION

We remove the IAM Role parameter from our two S3 bucket products to remove the security risk of a user giving too permissive access to the bucket.  Users should get access the same way they obtain access to other SC products (like EC2 instances), by obtaining an STS token returned by our system.  This is already possible and the user documentation has already been updated to instruct them to get access this way.

See https://sagebionetworks.jira.com/browse/SC-45 for further discussion.