### PR TITLE
[SC-306] Scheduled Jobs product

### DIFF
--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -1,0 +1,190 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: 'AWS Batch with Fargate'
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Container Image
+        Parameters:
+          - Image
+          - Command
+      - Label:
+          default: Synapse
+        Parameters:
+          - SynapsePAT
+      - Label:
+          default: Schedule Job
+        Parameters:
+          - EnableSchedule
+          - Schedule
+Parameters:
+  Image:
+    Type: String
+    Description: >
+      The container image to run, can be from dockerhub or from AWS ECR repository.
+    Default: "debian:latest"
+    ConstraintDescription: >
+      Must be a valid dockerhub or AWS ECR container image
+      Example: debian:latest or 111111111.dkr.ecr.us-east-1.amazonaws.com/MY-IMAGE:latest
+  Command:
+    Type: List<String>
+    Description: >
+      The list of commands to pass to the container image
+    ConstraintDescription: >
+      Must be a list of commands (i.e. ["echo", "hello", "world"])
+  EnableSchedule:
+    Description: >
+      true to run on a schedule, false to disable. If enabled a valid Schedule must be provided
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+  Schedule:
+    Description: >
+      Schedule to execute the docker, can be a rate or a cron schedule. Format at
+      https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+    Type: String
+    Default: cron(0 09 ? * MON *)  # Run every Monday at 9am
+    ConstraintDescription: "Use schedule format: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
+  SynapsePAT:
+    Type: String
+    NoEcho: true
+    Default: ""
+    Description: >
+      (Optional) The Synapse personal access token (PAT).
+      https://docs.synapse.org/rest/POST/personalAccessToken.html
+Resources:
+  ComputeEnvironment:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      Type: MANAGED
+      State: ENABLED
+      ServiceRole: !Ref ServiceRole
+      ComputeResources:
+        Type: FARGATE
+        MaxvCpus: 1
+        Subnets:
+          - !ImportValue us-east-1-scriptrunnervpc-PrivateSubnet
+          - !ImportValue us-east-1-scriptrunnervpc-PrivateSubnet1
+          - !ImportValue us-east-1-scriptrunnervpc-PrivateSubnet2
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+  ServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service:
+                - 'batch.amazonaws.com'
+            Action:
+              - 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole'
+  JobQueue:
+    Type: AWS::Batch::JobQueue
+    Properties:
+      ComputeEnvironmentOrder:
+        - ComputeEnvironment: !Ref ComputeEnvironment
+          Order: 1
+      Priority: 1
+      State: ENABLED
+  SchedulingPolicy:
+    Type: AWS::Batch::SchedulingPolicy
+    Properties:
+      FairsharePolicy:
+        ShareDecaySeconds: 5
+        ComputeReservation: 2
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !ImportValue us-east-1-scriptrunnervpc-VPCId
+      GroupDescription: !Sub 'SC for ${AWS::StackName}}'
+  JobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      JobDefinitionName: { Ref: "AWS::StackName" }
+      PropagateTags: True
+      PlatformCapabilities:
+        - FARGATE
+      Timeout:
+        AttemptDurationSeconds: 600
+      RetryStrategy:
+        Attempts: 1
+      ContainerProperties:
+        Command: !Ref Command
+        Image: !Ref Image
+        Environment:
+          - Name: SynapsePAT
+            Value: !Ref SynapsePAT
+        NetworkConfiguration:
+          AssignPublicIp: ENABLED
+        ResourceRequirements:
+          - Type: VCPU
+            Value: 0.5
+          - Type: MEMORY
+            Value: 1024
+        JobRoleArn: !GetAtt JobRole.Arn
+        ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            "awslogs-group": !Ref LogGroup
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+     AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service:
+                - 'ecs-tasks.amazonaws.com'
+            Action:
+              - 'sts:AssumeRole'
+     ManagedPolicyArns:
+       - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+  JobRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service:
+                - 'ecs-tasks.amazonaws.com'
+            Action:
+              - 'sts:AssumeRole'
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join [ '', [ '/', { Ref: 'AWS::StackName' }, '/log' ] ]
+      RetentionInDays: 14
+  BatchTrigger:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: 'https://bootstrap-awss3cloudformationbucket-19qromfd235z9.s3.amazonaws.com/lambda-batch-trigger/0.1.0/lambda-batch-trigger.yaml'
+      Parameters:
+        JobName: !Ref AWS::StackName
+        JobQueue: !Ref JobQueue
+        JobDefinition: !Ref JobDefinition
+        EnableSchedule: !Ref EnableSchedule
+        Schedule: !Ref Schedule
+Outputs:
+  SubmitJobApi:
+    Value: !GetAtt [BatchTrigger, Outputs.SubmitJobApi]
+  Jobs:
+    Value: !Sub 'https://console.aws.amazon.com/batch/home?region=${AWS::Region}#jobs'
+  JobQueue:
+    Value: !Sub 'https://console.aws.amazon.com/batch/home?region=${AWS::Region}#queues/detail/${JobQueue}'
+  JobDefinitions:
+    Value: !Sub 'https://console.aws.amazon.com/batch/home?region=${AWS::Region}#job-definition'
+  ComputeEnvironment:
+    Value: !Sub 'https://console.aws.amazon.com/batch/home?region=${AWS::Region}#compute-environments/detail/${ComputeEnvironment}'
+  Logs:
+    Value: !Sub 'https://console.aws.amazon.com/cloudwatch/home?region=${AWS::Region}#logsV2:log-groups/log-group/$252F${AWS::StackName}$252Flog'

--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -58,7 +58,7 @@ Parameters:
     Default: ""
     Description: >
       (Optional) The secrets passed to the docker container.
-    ConstraintDescription: 'Must be in "Key"="Value" form (i.e. "SECRET1":"Shh1","SECRET2":"Shh2")'
+    ConstraintDescription: 'Must be in "Key":"Value" form (i.e. "SECRET1":"Shh1","SECRET2":"Shh2")'
   EnvVars:
     Type: CommaDelimitedList
     Default: ""

--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -11,7 +11,7 @@ Metadata:
       - Label:
           default: Synapse
         Parameters:
-          - SynapsePAT
+          - SynapseAuthToken
       - Label:
           default: Schedule Job
         Parameters:
@@ -21,7 +21,7 @@ Parameters:
   Image:
     Type: String
     Description: >
-      The container image to run, can be from dockerhub or from AWS ECR repository.
+      The container image to run, must be from a public dockerhub or AWS ECR repository.
     Default: "debian:latest"
     ConstraintDescription: >
       Must be a valid dockerhub or AWS ECR container image
@@ -47,7 +47,7 @@ Parameters:
     Type: String
     Default: cron(0 09 ? * MON *)  # Run every Monday at 9am
     ConstraintDescription: "Use schedule format: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
-  SynapsePAT:
+  SynapseAuthToken:
     Type: String
     NoEcho: true
     Default: ""
@@ -129,10 +129,8 @@ Resources:
         Command: !Ref Command
         Image: !Ref Image
         Environment:
-          - Name: SynapsePAT
-            Value: !Ref SynapsePAT
-        NetworkConfiguration:
-          AssignPublicIp: ENABLED
+          - Name: SYNAPSE_AUTH_TOKEN
+            Value: !Ref SynapseAuthToken
         ResourceRequirements:
           - Type: VCPU
             Value: 0.5

--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -11,6 +11,7 @@ Metadata:
           default: Container Image
         Parameters:
           - Image
+          - Memory
           - Command
       - Label:
           default: Environment
@@ -31,12 +32,18 @@ Parameters:
     ConstraintDescription: >
       Must be a valid dockerhub or AWS ECR container image
       Example: debian:latest or 111111111.dkr.ecr.us-east-1.amazonaws.com/MY-IMAGE:latest
-  Command:
-    Type: List<String>
+  Memory:
     Description: >
-      The list of commands to pass to the container image
-    ConstraintDescription: >
-      Must be a list of commands (i.e. ["echo", "hello", "world"])
+      The amount (in MiB) of memory for the container. Mapping of memory to CpuShares for the
+      container is 1024: 0.25, 2048: 0.5, 4096: 1, 10240: 2, 18432: 4
+    Type: String
+    Default: "1024"
+    AllowedValues:
+      - "1024"
+      - "2048"
+      - "4096"
+      - "10240"
+      - "18432"
   EnableSchedule:
     Description: >
       true to run on a schedule, false to disable. If enabled a valid Schedule must be provided
@@ -45,6 +52,12 @@ Parameters:
     AllowedValues:
       - true
       - false
+  Command:
+    Type: List<String>
+    Description: >
+      The list of commands to pass to the container image
+    ConstraintDescription: >
+      Must be a list of commands (i.e. ["echo", "hello", "world"])
   Schedule:
     Description: >
       Schedule to execute the docker, can be a rate or a cron schedule. Format at
@@ -66,6 +79,18 @@ Parameters:
       (Optional) The environment variables passed to the docker container.
     ConstraintDescription: Must be in Key=Value form (i.e. VAR1=One,VAR2=Two)
 Transform: [PyPlate]
+Mappings:
+  VpcuMemoryMap:
+    "1024":
+      CpuShares: 0.25
+    "2048":
+      CpuShares: 0.50
+    "4096":
+      CpuShares: 1
+    "10240":
+      CpuShares: 2
+    "18432":
+      CpuShares: 4
 Resources:
   ComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
@@ -177,10 +202,10 @@ Resources:
         Secrets:
           - {"Name":"ScriptRunnerSecrets", "ValueFrom":!Ref ScriptRunnerSecrets}
         ResourceRequirements:
-          - Type: VCPU
-            Value: 0.5
           - Type: MEMORY
-            Value: 1024
+            Value: !Ref Memory
+          - Type: VCPU
+            Value: !FindInMap [VpcuMemoryMap, !Ref Memory, CpuShares]
         JobRoleArn: !GetAtt JobRole.Arn
         ExecutionRoleArn: !GetAtt ExecutionRole.Arn
         LogConfiguration:

--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -35,7 +35,7 @@ Parameters:
   Memory:
     Description: >
       The amount (in MiB) of memory for the container. Mapping of memory to CpuShares for the
-      container is 1024: 0.25, 2048: 0.5, 4096: 1, 10240: 2, 18432: 4
+      container is 1024:0.25, 2048:0.5, 4096:1, 10240:2, 18432:4
     Type: String
     Default: "1024"
     AllowedValues:
@@ -44,6 +44,9 @@ Parameters:
       - "4096"
       - "10240"
       - "18432"
+    ConstraintDescription: >
+      Memory and CPU shares must be a matched set, the relationship can be found at
+      https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-resourcerequirement.html
   EnableSchedule:
     Description: >
       true to run on a schedule, false to disable. If enabled a valid Schedule must be provided

--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -57,6 +57,11 @@ Parameters:
 Resources:
   ComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3008
     Properties:
       Type: MANAGED
       State: ENABLED
@@ -94,6 +99,11 @@ Resources:
       State: ENABLED
   SchedulingPolicy:
     Type: AWS::Batch::SchedulingPolicy
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3001
     Properties:
       FairsharePolicy:
         ShareDecaySeconds: 5

--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -1,6 +1,10 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: 'AWS Batch with Fargate'
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:  # Ignore cfn-lint errors for PyPlate.
+        - W2001
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -9,9 +13,10 @@ Metadata:
           - Image
           - Command
       - Label:
-          default: Synapse
+          default: Environment
         Parameters:
-          - SynapseAuthToken
+          - Secrets
+          - EnvVars
       - Label:
           default: Schedule Job
         Parameters:
@@ -47,13 +52,20 @@ Parameters:
     Type: String
     Default: cron(0 09 ? * MON *)  # Run every Monday at 9am
     ConstraintDescription: "Use schedule format: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
-  SynapseAuthToken:
+  Secrets:
     Type: String
     NoEcho: true
     Default: ""
     Description: >
-      (Optional) The Synapse personal access token (PAT).
-      https://docs.synapse.org/rest/POST/personalAccessToken.html
+      (Optional) The secrets passed to the docker container.
+    ConstraintDescription: 'Must be in "Key"="Value" form (i.e. "SECRET1":"Shh1","SECRET2":"Shh2")'
+  EnvVars:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: >
+      (Optional) The environment variables passed to the docker container.
+    ConstraintDescription: Must be in Key=Value form (i.e. VAR1=One,VAR2=Two)
+Transform: [PyPlate]
 Resources:
   ComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
@@ -113,7 +125,35 @@ Resources:
     Properties:
       VpcId: !ImportValue us-east-1-scriptrunnervpc-VPCId
       GroupDescription: !Sub 'SC for ${AWS::StackName}}'
+  ScriptRunnerSecrets:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      SecretString: !Sub '{ ${Secrets} }'
+  # Allow read access to ScriptRunnerSecrets
+  # https://docs.aws.amazon.com/mediaconnect/latest/ug/iam-policy-examples-asm-secrets.html
+  SecretsAccessPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - secretsmanager:GetResourcePolicy
+              - secretsmanager:GetSecretValue
+              - secretsmanager:DescribeSecret
+              - secretsmanager:ListSecretVersionIds
+            Resource:
+              - !Ref ScriptRunnerSecrets
+          - Effect: Allow
+            Action: secretsmanager:ListSecrets
+            Resource: '*'
   JobDefinition:
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:  # Ignore cfn-lint errors for PyPlate.
+            - E3002
     Type: AWS::Batch::JobDefinition
     Properties:
       Type: container
@@ -128,9 +168,14 @@ Resources:
       ContainerProperties:
         Command: !Ref Command
         Image: !Ref Image
-        Environment:
-          - Name: SYNAPSE_AUTH_TOKEN
-            Value: !Ref SynapseAuthToken
+        Environment: |
+          #!PyPlate
+          output = []
+          for tag in params['EnvVars']:
+             key, value = tag.split('=')
+             output.append({"Name": key, "Value": value})
+        Secrets:
+          - {"Name":"ScriptRunnerSecrets", "ValueFrom":!Ref ScriptRunnerSecrets}
         ResourceRequirements:
           - Type: VCPU
             Value: 0.5
@@ -156,6 +201,7 @@ Resources:
               - 'sts:AssumeRole'
      ManagedPolicyArns:
        - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+       - !Ref SecretsAccessPolicy
   JobRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -186,6 +232,8 @@ Resources:
 Outputs:
   SubmitJobApi:
     Value: !GetAtt [BatchTrigger, Outputs.SubmitJobApi]
+  ScriptRunnerSecretsArn:
+    Value: !Ref ScriptRunnerSecrets
   Jobs:
     Value: !Sub 'https://console.aws.amazon.com/batch/home?region=${AWS::Region}#jobs'
   JobQueue:


### PR DESCRIPTION
Add a SC product to run cron jobs on a schedule.  The cron jobs
will be run as AWS batch jobs.  Users can set the job to run on
a schedule or they can manually trigger the job with the submit
job API.

depends on https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/317 https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/320
