### PR TITLE
[SC-306] Workaround for empty parameters

### DIFF
--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -59,9 +59,9 @@ Parameters:
   Command:
     Type: String
     Description: >
-      A pipe seperated list of commands to pass to the container image (i.e. echo|hello|world)
+      A pipe separated list which is the command to pass to the container (i.e. echo|hello|world)
     ConstraintDescription: >
-      Must be a pipe delimited string of commands
+      Must be a pipe delimited list of strings
   Schedule:
     Description: >
       Schedule to execute the docker, can be a rate or a cron schedule. Format at
@@ -75,13 +75,13 @@ Parameters:
     Default: '"SECRET1":"Shh1"'
     Description: >
       The secrets passed to the docker container (i.e. "SECRET1":"Shh1","SECRET2":"Shh2")
-    ConstraintDescription: 'Must be in "Key":"Value" form'
+    ConstraintDescription: 'Must be in "Key":"Value" form, and cannot be omitted'
   EnvVars:
     Type: CommaDelimitedList
     Default: 'SCHEDULED_JOB_VAR1=one'
     Description: >
       The environment variables passed to the docker container (i.e. VAR1=One,VAR2=Two)
-    ConstraintDescription: 'Must be in Key=Value form'
+    ConstraintDescription: 'Must be in Key=Value form, and cannot be omitted'
 Transform: [PyPlate]
 Mappings:
   VpcuMemoryMap:

--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -57,30 +57,30 @@ Parameters:
       - true
       - false
   Command:
-    Type: List<String>
+    Type: String
     Description: >
-      The list of commands to pass to the container image (i.e. ["echo", "hello", "world"])
+      A pipe seperated list of commands to pass to the container image (i.e. echo|hello|world)
     ConstraintDescription: >
-      Must be a list of commands
+      Must be a pipe delimited string of commands
   Schedule:
     Description: >
       Schedule to execute the docker, can be a rate or a cron schedule. Format at
       https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
     Type: String
-    Default: cron(0 09 ? * MON *)  # Run every Monday at 9am
+    Default: rate(7 days)  # Run once a week
     ConstraintDescription: "Use schedule format: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
   Secrets:
     Type: String
     NoEcho: true
-    Default: ""
+    Default: '"SECRET1":"Shh1"'
     Description: >
-      (Optional) The secrets passed to the docker container (i.e. "SECRET1":"Shh1","SECRET2":"Shh2")
+      The secrets passed to the docker container (i.e. "SECRET1":"Shh1","SECRET2":"Shh2")
     ConstraintDescription: 'Must be in "Key":"Value" form'
   EnvVars:
     Type: CommaDelimitedList
-    Default: ""
+    Default: 'SCHEDULED_JOB_VAR1=one'
     Description: >
-      (Optional) The environment variables passed to the docker container (i.e. VAR1=One,VAR2=Two)
+      The environment variables passed to the docker container (i.e. VAR1=One,VAR2=Two)
     ConstraintDescription: 'Must be in Key=Value form'
 Transform: [PyPlate]
 Mappings:
@@ -195,7 +195,7 @@ Resources:
       RetryStrategy:
         Attempts: 1
       ContainerProperties:
-        Command: !Ref Command
+        Command: !Split [ "|" , !Ref Command ]
         Image: !Ref Image
         Environment: |
           #!PyPlate
@@ -204,7 +204,7 @@ Resources:
              key, value = tag.split('=')
              output.append({"Name": key, "Value": value})
         Secrets:
-          - {"Name":"JobSecrets", "ValueFrom":!Ref JobSecrets}
+          - {"Name":"SCHEDULED_JOB_SECRETS", "ValueFrom":!Ref JobSecrets}
         ResourceRequirements:
           - Type: MEMORY
             Value: !Ref Memory


### PR DESCRIPTION
The only workaround that I could find for allowing empty Secret and EnvVar parameters
is to not allow it at all.  Instead we set default values and user either needs to
accept the default values or replace them with their own VARS.  Setting the parameters
to an empty string will cause the deployment to fail.

