### PR TITLE
[SC-306] fix required parameters

### DIFF
--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -32,7 +32,7 @@ Parameters:
     ConstraintDescription: >
       Must be a valid dockerhub or AWS ECR container image
       Example: debian:latest or 111111111.dkr.ecr.us-east-1.amazonaws.com/MY-IMAGE:latest
-    AllowedPattern: ".+"
+    AllowedPattern: "^(?!s*$).+"
   Memory:
     Description: >
       The amount (in MiB) of memory for the container. Mapping of memory to CpuShares for the
@@ -63,7 +63,8 @@ Parameters:
       A pipe separated list which is the command to pass to the container (i.e. echo|hello|world)
     ConstraintDescription: >
       Must be a pipe delimited list of strings
-    AllowedPattern: ".+"
+    Default: "echo|hello|world"
+    AllowedPattern: "^(?!s*$).+"
   Schedule:
     Description: >
       Schedule to execute the docker, can be a rate or a cron schedule. Format at
@@ -71,7 +72,7 @@ Parameters:
     Type: String
     Default: rate(7 days)  # Run once a week
     ConstraintDescription: "Use schedule format: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
-    AllowedPattern: ".+"
+    AllowedPattern: "^(?!s*$).+"
   Secrets:
     Type: String
     NoEcho: true
@@ -79,14 +80,13 @@ Parameters:
     Description: >
       The secrets passed to the docker container (i.e. "SECRET1":"Shh1","SECRET2":"Shh2")
     ConstraintDescription: 'Must be in "Key":"Value" form, and cannot be omitted'
-    AllowedPattern: ".+"
+    AllowedPattern: "^(?!s*$).+"
   EnvVars:
     Type: CommaDelimitedList
     Default: 'SCHEDULED_JOB_VAR1=one'
     Description: >
       The environment variables passed to the docker container (i.e. VAR1=One,VAR2=Two)
     ConstraintDescription: 'Must be in Key=Value form, and cannot be omitted'
-    AllowedPattern: ".+"
 Transform: [PyPlate]
 Mappings:
   VpcuMemoryMap:


### PR DESCRIPTION
* Remove AllowedPattern from EnvVars because that's a CommaDelimitedList
  parameter which does not support AllowedPattern
* AllowedPattern requires a default value to validate the parameter
  therefore we need to add a default to the Command parmeter
* Use regex from example https://www.examplefiles.net/cs/122000

