### PR TITLE
[SC-373] Make Command parameter optional

### DIFF
--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -60,9 +60,7 @@ Parameters:
   Command:
     Type: String
     Description: >
-      (Optional) A comma separated list which is the command to pass to the container (i.e. echo,hello,world).
-    ConstraintDescription: >
-      Must be either empty or a comma delimited list of strings.
+      (Optional) The command that's passed to the docker container (i.e. echo hello world).
     Default: ""
   Schedule:
     Description: >
@@ -201,7 +199,7 @@ Resources:
       RetryStrategy:
         Attempts: 1
       ContainerProperties:
-        Command: !If [HasCommand, !Split [ "," , !Ref Command ], !Ref 'AWS::NoValue']
+        Command: !If [HasCommand, !Ref Command, !Ref 'AWS::NoValue']
         Image: !Ref Image
         Environment: |
           #!PyPlate

--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -60,7 +60,7 @@ Parameters:
   Command:
     Type: String
     Description: >
-      (Optional) The command that's passed to the docker container (i.e. echo hello world).
+      (Optional) The command that's passed to the docker container (e.g. echo hello world).
     Default: ""
   Schedule:
     Description: >

--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -60,11 +60,10 @@ Parameters:
   Command:
     Type: String
     Description: >
-      A pipe separated list which is the command to pass to the container (i.e. echo|hello|world)
+      (Optional) A comma separated list which is the command to pass to the container (i.e. echo,hello,world).
     ConstraintDescription: >
-      Must be a pipe delimited list of strings
-    Default: "echo|hello|world"
-    AllowedPattern: "^(?!s*$).+"
+      Must be either empty or a comma delimited list of strings.
+    Default: ""
   Schedule:
     Description: >
       Schedule to execute the docker, can be a rate or a cron schedule. Format at
@@ -87,6 +86,8 @@ Parameters:
     Description: >
       The environment variables passed to the docker container (i.e. VAR1=One,VAR2=Two)
     ConstraintDescription: 'Must be in Key=Value form, and cannot be omitted'
+Conditions:
+  HasCommand: !Not [!Equals [!Ref Command, ""]]
 Transform: [PyPlate]
 Mappings:
   VpcuMemoryMap:
@@ -200,7 +201,7 @@ Resources:
       RetryStrategy:
         Attempts: 1
       ContainerProperties:
-        Command: !Split [ "|" , !Ref Command ]
+        Command: !If [HasCommand, !Split [ "," , !Ref Command ], !Ref 'AWS::NoValue']
         Image: !Ref Image
         Environment: |
           #!PyPlate


### PR DESCRIPTION
* A dockerfile may run the require commands so user may not
  need to pass in a command to run.  This makes the command an
  optional input parameter.
* Change the separater to space instead of pipe to match how the user
  passes in the command using the docker CLI,
  https://docs.docker.com/engine/reference/builder/#cmd

