### PR TITLE
[SC-306] Fix Command parameter

### DIFF
--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -191,7 +191,7 @@ Resources:
     Properties:
       Type: container
       JobDefinitionName: { Ref: "AWS::StackName" }
-      PropagateTags: True
+      PropagateTags: true
       PlatformCapabilities:
         - FARGATE
       Timeout:

--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -199,7 +199,7 @@ Resources:
       RetryStrategy:
         Attempts: 1
       ContainerProperties:
-        Command: !If [HasCommand, !Ref Command, !Ref 'AWS::NoValue']
+        Command: !If [HasCommand, !Split [ " " , !Ref Command ], !Ref 'AWS::NoValue']
         Image: !Ref Image
         Environment: |
           #!PyPlate


### PR DESCRIPTION
The scheuled jobs product failed to deploy because the ContainerProperties
Command expects a list of strings.

```
Property validation failure: [Value of property {/ContainerProperties/Command} does not match type {Array}]
```

To fix that we need to use the CFN split function to create a list from
a space delimited string of commands.

