### PR TITLE
[SC-379] update scheduled jobs product with tagging

### DIFF
--- a/batch/sc-batch-fargate.yaml
+++ b/batch/sc-batch-fargate.yaml
@@ -262,6 +262,16 @@ Resources:
         JobDefinition: !Ref JobDefinition
         EnableSchedule: !Ref EnableSchedule
         Schedule: !Ref Schedule
+  BatchTagger:
+    Type: Custom::SynapseTagger
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetBatchTagsFunctionArn'
+      BatchResources:
+        JobDefinitionArn: !Ref JobDefinition
+        JobQueueArn: !Ref JobQueue
+        ComputeEnvironmentArn: !Ref ComputeEnvironment
+        SchedulingPolicyArn: !Ref SchedulingPolicy
 Outputs:
   SubmitJobApi:
     Value: !GetAtt [BatchTrigger, Outputs.SubmitJobApi]


### PR DESCRIPTION
Setup a lambda to tag each batch resource for the scheduled jobs
product. The lambda gets triggered when a user provisions the
scheduled jobs product in the service catalog

depends on https://github.com/Sage-Bionetworks-IT/cfn-cr-synapse-tagger/pull/30