### PR TITLE
[IT-1234] AWS Security group for TGW

### DIFF
--- a/ec2/sc-ec2-linux-docker.yaml
+++ b/ec2/sc-ec2-linux-docker.yaml
@@ -135,6 +135,22 @@ Parameters:
     MinValue: 16
     MaxValue: 5000
 Resources:
+  TgwHubSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W1011
+    Properties:
+      GroupDescription: 'Allow network access from TGW Hub'
+      VpcId: !ImportValue
+        'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VPCId]
+      SecurityGroupIngress:
+        - CidrIp: "10.50.0.0/16"
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
   InstanceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -237,6 +253,10 @@ Resources:
       InstanceType: !Ref 'EC2InstanceType'
       SubnetId: !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", PrivateSubnet]
+      SecurityGroupIds:
+        - !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
+        - !Ref TgwHubSecurityGroup
       BlockDeviceMappings:
         - DeviceName: "/dev/xvda"
           Ebs:

--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -184,6 +184,23 @@ Resources:
           SourceSecurityGroupId: !ImportValue
             'Fn::Sub': '${AWS::Region}-alb-notebook-access-ALBSecurityGroup'
 
+  AwsVpnSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W1011
+    Properties:
+      GroupDescription: 'Allow network access from TGW Hub'
+      VpcId: !ImportValue
+        'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VPCId]
+      SecurityGroupIngress:
+        - CidrIp: "10.50.0.0/16"
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -384,6 +401,7 @@ Resources:
         - !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
         - !Ref NotebookConnectSecurityGroup
+        - !Ref AwsVpnSecurityGroup
       KeyName: 'scipool'
       BlockDeviceMappings:
         -

--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -184,7 +184,7 @@ Resources:
           SourceSecurityGroupId: !ImportValue
             'Fn::Sub': '${AWS::Region}-alb-notebook-access-ALBSecurityGroup'
 
-  AwsVpnSecurityGroup:
+  TgwHubSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Metadata:
       cfn-lint:
@@ -401,7 +401,7 @@ Resources:
         - !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
         - !Ref NotebookConnectSecurityGroup
-        - !Ref AwsVpnSecurityGroup
+        - !Ref TgwHubSecurityGroup
       KeyName: 'scipool'
       BlockDeviceMappings:
         -

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -191,6 +191,7 @@ Resources:
       SecurityGroupIds:
         - !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
+        - !Ref AwsVpnSecurityGroup
       KeyName: 'scipool'
       IamInstanceProfile: !Ref 'InstanceProfile'
       BlockDeviceMappings:
@@ -225,6 +226,22 @@ Resources:
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetInstanceTagsFunctionArn'
       InstanceId: !Ref WindowsInstance
+  AwsVpnSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W1011
+    Properties:
+      GroupDescription: 'Allow network access from TGW Hub'
+      VpcId: !ImportValue
+        'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VPCId]
+      SecurityGroupIngress:
+        - CidrIp: "10.50.0.0/16"
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
 Outputs:
   WindowsInstancePrivateIpAddress:
     Description: 'The IP Address of the EC2 instance'

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -191,7 +191,7 @@ Resources:
       SecurityGroupIds:
         - !ImportValue
           'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
-        - !Ref AwsVpnSecurityGroup
+        - !Ref TgwHubSecurityGroup
       KeyName: 'scipool'
       IamInstanceProfile: !Ref 'InstanceProfile'
       BlockDeviceMappings:
@@ -226,7 +226,7 @@ Resources:
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetInstanceTagsFunctionArn'
       InstanceId: !Ref WindowsInstance
-  AwsVpnSecurityGroup:
+  TgwHubSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Metadata:
       cfn-lint:


### PR DESCRIPTION
We use the transit gateway to route traffic between the hub
and spoke VPCs. To allow access to resources in a spoke VPC we need
to give the hub VPC access to the resources. This adds an SG ingress
to resources provisioned in our spoke VPCs which will allow VPN users
access to the resources in the spoke VPCs.

