### PR TITLE
SC-383: Updating AMI for RStudio Notebook

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -24,7 +24,7 @@ Metadata:
 Mappings:
   NotebookTypes:
     Rstudio:
-      AMIID: "ami-0588ce2d8084e56be" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v2.1.3
+      AMIID: "ami-0d95d262d92cd5b77" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v2.1.6
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'


### PR DESCRIPTION
SC-383: Updating the version of R and R Studio used in the RStudio Notebook product.  This updates the Notebook to use the new AMI built with Packer.
