### PR TITLE
Revert "SC-383: Updating AMI for RStudio Notebook"

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -24,7 +24,7 @@ Metadata:
 Mappings:
   NotebookTypes:
     Rstudio:
-      AMIID: "ami-0d95d262d92cd5b77" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v2.1.6
+      AMIID: "ami-0588ce2d8084e56be" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v2.1.3
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'


### PR DESCRIPTION
This reverts commit b6cde24904f9bc949c38c380863ad8211c66a84b.
The packer-rstudio v2.1.6 is broken. Reverting back to last
known good AMI