### PR TITLE
[IT-2075] Disable S3 bucket ACLs

### DIFF
--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -60,7 +60,7 @@ Resources:
             MaxAge: 3000
       OwnershipControls:
         Rules:
-          - ObjectOwnership: BucketOwnerPreferred
+          - ObjectOwnership: BucketOwnerEnforced
       LifecycleConfiguration:
         Rules:
           - Id: IntelligentTieringClassTransitionRule


### PR DESCRIPTION
Disable ACLs to simplify access management of data
in S3 buckets.  This is a recommendation by AWS

https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-s3-object-ownership-simplify-access-management-data-s3/

