### PR TITLE
[IT-2132] Propagate tags from instance to volumes

### DIFF
--- a/ec2/sc-ec2-linux-docker.yaml
+++ b/ec2/sc-ec2-linux-docker.yaml
@@ -269,6 +269,7 @@ Resources:
           #!/bin/bash
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource EC2Instance --configsets SetupCfn,SetEnv --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource EC2Instance --region ${AWS::Region}
+      PropagateTagsToVolumeOnCreation: true
       Tags:
         - Key: Name
           Value: !Ref 'AWS::StackName'

--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -416,6 +416,7 @@ Resources:
           #!/bin/bash
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupApacheProxy,SetupSynapseCredEnv --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
+      PropagateTagsToVolumeOnCreation: true
       Tags:
         - Key: Name
           Value: !Ref 'AWS::StackName'

--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -207,6 +207,7 @@ Resources:
           cfn-init.exe -v --stack ${AWS::StackId} --resource WindowsInstance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetEnv,SetupJumpcloud
           cfn-signal.exe -e %errorlevel% --stack ${AWS::StackId} --resource WindowsInstance --region ${AWS::Region}
           </script>
+      PropagateTagsToVolumeOnCreation: true
       Tags:
         - Key: Name
           Value: !Ref 'AWS::StackName'


### PR DESCRIPTION
Propagate the Service Catalog tags from the EC2 instance to its associated EBS volumes.
