### PR TITLE
[SC-383] Update EC2 notebook with new AMI

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -24,7 +24,7 @@ Metadata:
 Mappings:
   NotebookTypes:
     Rstudio:
-      AMIID: "ami-0588ce2d8084e56be" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v2.1.3
+      AMIID: "ami-01482e41c3d57b763" # packer-rstudio-master
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'

--- a/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -24,7 +24,7 @@ Metadata:
 Mappings:
   NotebookTypes:
     Rstudio:
-      AMIID: "ami-01482e41c3d57b763" # packer-rstudio-master
+      AMIID: "ami-01482e41c3d57b763" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v3.0.0
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'


### PR DESCRIPTION
New AMI contains newer distro and apps versions:

* Ubuntu 22.04 (jammy jellyfish)
* python 3.10.6
* rstudio server 2023.03.1+446 (Cherry Blossom) for Ubuntu Jammy
* apache 2.4.52

depends on https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-jammy/pull/1  https://github.com/Sage-Bionetworks-IT/packer-rstudio/pull/65
