### PR TITLE
Update AMI for rstudio notebook product

### DIFF
--- a/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -24,7 +24,7 @@ Metadata:
 Mappings:
   NotebookTypes:
     Rstudio:
-      AMIID: "ami-08cd5d5244f82a25c" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v3.0.1
+      AMIID: "ami-09a02d2456a2a8908" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v3.0.2
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'


### PR DESCRIPTION
Update packer-rstudio AMI image

depends on https://github.com/Sage-Bionetworks-IT/packer-rstudio/pull/69

