### PR TITLE
SC-383: Update OS/R4.1/RStudio202203

### DIFF
--- a/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -24,7 +24,7 @@ Metadata:
 Mappings:
   NotebookTypes:
     Rstudio:
-      AMIID: "ami-0c57de1df1690007e" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v3.0.3
+      AMIID: "ami-097a388987a40d952" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v3.0.3
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'

--- a/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -24,7 +24,7 @@ Metadata:
 Mappings:
   NotebookTypes:
     Rstudio:
-      AMIID: "ami-09a02d2456a2a8908" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v3.0.2
+      AMIID: "ami-0c57de1df1690007e" # https://github.com/Sage-Bionetworks-IT/packer-rstudio/tree/v3.0.3
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'


### PR DESCRIPTION
This PR updates the notebook product to Ubuntu2022/R4.1/RStudio202203. This is an attempt to move forward in upgrading the product.

Depends on https://github.com/Sage-Bionetworks-IT/packer-rstudio/pull/74

