### PR TITLE
[IT-3019] Fix scheduled jobs

### DIFF
--- a/templates/batch/sc-batch-fargate.yaml
+++ b/templates/batch/sc-batch-fargate.yaml
@@ -132,7 +132,7 @@ Resources:
       ServiceRole: !Ref ServiceRole
       ComputeResources:
         Type: FARGATE
-        MaxvCpus: 1
+        MaxvCpus: 16
         Subnets:
           - !ImportValue us-east-1-scheduledjobsvpc-PrivateSubnet
           - !ImportValue us-east-1-scheduledjobsvpc-PrivateSubnet1


### PR DESCRIPTION
The batch jobs are still not able to run because large memory jobs require more VCPU.  The batch docs[1] says
`16384 (VCPU = 2, 4, or 8)`, the ECS doc[2] says `16384 (16 vCPU)` and the cloudformation doc[3] says `16384 (16vCPU)`.  Since the parameter indicates it's a max setting we go with `16 vPCU`.

[1] https://docs.aws.amazon.com/batch/latest/APIReference/API_ResourceRequirement.html
[2] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
[3] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-memory
