### PR TITLE
SC-383: Bump version to take bugfix

### DIFF
--- a/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -346,7 +346,7 @@ Resources:
         set_env_vars:
           files:
             /opt/sage/bin/make_env_vars_file.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v2.0.1/linux/opt/sage/bin/make_env_vars_file.sh"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v2.0.2/linux/opt/sage/bin/make_env_vars_file.sh"
               mode: "00744"
               owner: "root"
               group: "root"
@@ -360,7 +360,7 @@ Resources:
         write_apache_conf:
           files:
             /opt/sage/bin/apache_conf_rewrite.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v2.0.1/linux/opt/sage/bin/apache_conf_rewrite.sh"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v2.0.2/linux/opt/sage/bin/apache_conf_rewrite.sh"
               mode: "00744"
               owner: "root"
               group: "root"
@@ -370,12 +370,12 @@ Resources:
         write_synapse_env:
           files:
             /opt/sage/bin/apache_synapse_cred_env.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v2.0.1/linux/opt/sage/bin/apache_synapse_cred_env.sh"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v2.0.2/linux/opt/sage/bin/apache_synapse_cred_env.sh"
               mode: "00744"
               owner: "root"
               group: "root"
             /opt/sage/bin/rstudio_synapse_cred_env.sh:
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v2.0.1/linux/opt/sage/bin/rstudio_synapse_cred_env.sh"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/service-catalog-utils/v2.0.2/linux/opt/sage/bin/rstudio_synapse_cred_env.sh"
               mode: "00744"
               owner: "root"
               group: "root"


### PR DESCRIPTION
This PR updates the service-catalog-utility scripts to pick up https://github.com/Sage-Bionetworks/service-catalog-utils/pull/23 . 

