### PR TITLE
[IT-3222] Only allow AMD instances

### DIFF
--- a/templates/ec2/sc-ec2-linux-docker.yaml
+++ b/templates/ec2/sc-ec2-linux-docker.yaml
@@ -33,81 +33,6 @@ Mappings:
 Parameters:
   EC2InstanceType:
     AllowedValues:
-      - c5.large
-      - c5.xlarge
-      - c5.2xlarge
-      - c5.4xlarge
-      - c5d.large
-      - c5d.xlarge
-      - c5d.2xlarge
-      - c5d.4xlarge
-      - c5n.large
-      - c5n.xlarge
-      - c5n.2xlarge
-      - c5n.4xlarge
-      - i3en.large
-      - i3en.xlarge
-      - i3en.2xlarge
-      - g4dn.xlarge
-      - g4dn.2xlarge
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - m5a.large
-      - m5a.xlarge
-      - m5a.2xlarge
-      - m5a.4xlarge
-      - m5ad.large
-      - m5ad.xlarge
-      - m5ad.2xlarge
-      - m5ad.4xlarge
-      - m5d.large
-      - m5d.xlarge
-      - m5d.2xlarge
-      - m5d.4xlarge
-      - m5dn.large
-      - m5dn.xlarge
-      - m5dn.2xlarge
-      - m5dn.4xlarge
-      - m5n.large
-      - m5n.xlarge
-      - m5n.2xlarge
-      - m5n.4xlarge
-      - r5.large
-      - r5.xlarge
-      - r5.2xlarge
-      - r5.4xlarge
-      - r5a.large
-      - r5a.xlarge
-      - r5a.2xlarge
-      - r5a.4xlarge
-      - r5ad.large
-      - r5ad.xlarge
-      - r5ad.2xlarge
-      - r5ad.4xlarge
-      - r5d.large
-      - r5d.xlarge
-      - r5d.2xlarge
-      - r5d.4xlarge
-      - r5dn.large
-      - r5dn.xlarge
-      - r5dn.2xlarge
-      - r5n.large
-      - r5n.xlarge
-      - r5n.2xlarge
-      - r5n.4xlarge
-      - t3.nano
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - t3.xlarge
-      - t3.2xlarge
       - t3a.nano
       - t3a.micro
       - t3a.small
@@ -115,11 +40,28 @@ Parameters:
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
-      - x2gd.medium
-      - x2gd.large
-      - x2gd.xlarge
-      - x2gd.2xlarge
-    Default: t3.micro
+      - m7a.medium
+      - m7a.large
+      - m7a.xlarge
+      - m7a.2xlarge
+      - m7a.4xlarge
+      - m7a.8xlarge
+      - c7a.medium
+      - c7a.large
+      - c7a.xlarge
+      - c7a.2xlarge
+      - c7a.4xlarge
+      - c7a.8xlarge
+      - r7a.medium
+      - r7a.large
+      - r7a.xlarge
+      - r7a.2xlarge
+      - r7a.4xlarge
+      - r7a.8xlarge
+      - g5.xlarge
+      - g5.2xlarge
+      - g5.4xlarge
+    Default: t3a.small
     Description: Amazon EC2 Instance Type
     Type: String
   AMI:

--- a/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -36,81 +36,6 @@ Parameters:
 
   EC2InstanceType:
     AllowedValues:
-      - c5.large
-      - c5.xlarge
-      - c5.2xlarge
-      - c5.4xlarge
-      - c5d.large
-      - c5d.xlarge
-      - c5d.2xlarge
-      - c5d.4xlarge
-      - c5n.large
-      - c5n.xlarge
-      - c5n.2xlarge
-      - c5n.4xlarge
-      - i3en.large
-      - i3en.xlarge
-      - i3en.2xlarge
-      - g4dn.xlarge
-      - g4dn.2xlarge
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - m5a.large
-      - m5a.xlarge
-      - m5a.2xlarge
-      - m5a.4xlarge
-      - m5ad.large
-      - m5ad.xlarge
-      - m5ad.2xlarge
-      - m5ad.4xlarge
-      - m5d.large
-      - m5d.xlarge
-      - m5d.2xlarge
-      - m5d.4xlarge
-      - m5dn.large
-      - m5dn.xlarge
-      - m5dn.2xlarge
-      - m5dn.4xlarge
-      - m5n.large
-      - m5n.xlarge
-      - m5n.2xlarge
-      - m5n.4xlarge
-      - r5.large
-      - r5.xlarge
-      - r5.2xlarge
-      - r5.4xlarge
-      - r5a.large
-      - r5a.xlarge
-      - r5a.2xlarge
-      - r5a.4xlarge
-      - r5ad.large
-      - r5ad.xlarge
-      - r5ad.2xlarge
-      - r5ad.4xlarge
-      - r5d.large
-      - r5d.xlarge
-      - r5d.2xlarge
-      - r5d.4xlarge
-      - r5dn.large
-      - r5dn.xlarge
-      - r5dn.2xlarge
-      - r5n.large
-      - r5n.xlarge
-      - r5n.2xlarge
-      - r5n.4xlarge
-      - t3.nano
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - t3.xlarge
-      - t3.2xlarge
       - t3a.nano
       - t3a.micro
       - t3a.small
@@ -118,11 +43,28 @@ Parameters:
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
-      - x2gd.medium
-      - x2gd.large
-      - x2gd.xlarge
-      - x2gd.2xlarge
-    Default: t3.small
+      - m7a.medium
+      - m7a.large
+      - m7a.xlarge
+      - m7a.2xlarge
+      - m7a.4xlarge
+      - m7a.8xlarge
+      - c7a.medium
+      - c7a.large
+      - c7a.xlarge
+      - c7a.2xlarge
+      - c7a.4xlarge
+      - c7a.8xlarge
+      - r7a.medium
+      - r7a.large
+      - r7a.xlarge
+      - r7a.2xlarge
+      - r7a.4xlarge
+      - r7a.8xlarge
+      - g5.xlarge
+      - g5.2xlarge
+      - g5.4xlarge
+    Default: t3a.small
     Description: Amazon EC2 Instance Type
     Type: String
 

--- a/templates/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/templates/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -20,13 +20,12 @@ Metadata:
 Parameters:
   WindowsInstanceType:
     AllowedValues:
-      - t3.nano
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - t3.xlarge
-    Default: t3.small
+      - t3a.small
+      - t3a.medium
+      - t3a.large
+      - t3a.xlarge
+      - t3a.2xlarge
+    Default: t3a.small
     Description: Amazon EC2 Instance Type
     Type: String
   VolumeSize:


### PR DESCRIPTION
We have decided that the best option to balance performance, compability and cost would be to only allow the use of AMD instances[1] in the service catalog.  This change restricts the list of instances users get to select when provisioning service catalog EC2 instances.  It also attempts to reduce the number of instance types that we support by removing redundant types.

[1] https://aws.amazon.com/ec2/instance-types/

depends on #312 