### PR TITLE
Update pre-commit linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       entry: git-secrets
       args: [--scan, --recursive]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     # On Windows, git will convert all CRLF to LF,
     # but only after all hooks are done executing.
@@ -22,16 +22,16 @@ repos:
     hooks:
     -   id: yamllint
 -   repo: https://github.com/aws-cloudformation/cfn-python-lint
-    rev: v0.77.6
+    rev: v0.83.1
     hooks:
     -   id: cfn-python-lint
         files: .*/.*\.(json|yml|yaml)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.1
+    rev: v1.5.4
     hooks:
     -   id: remove-tabs
 -   repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.22.0
+    rev: 0.27.1
     hooks:
       - id: check-github-workflows
       - id: check-github-actions

--- a/templates/s3/sc-s3-encrypted-ra.yaml
+++ b/templates/s3/sc-s3-encrypted-ra.yaml
@@ -37,7 +37,6 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
-      AccessControl: Private
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:


### PR DESCRIPTION
update of pre-commit linters resulted in this warning..
```
W3045 Consider using AWS::S3::BucketPolicy instead of AccessControl
templates/s3/sc-s3-encrypted-ra.yaml:40:7
```

Remove AccessControl setting because it is now disabled by default and bucket owner enforced is enabled by default.  This is what AWS recommends[1]

[1] https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html#requiring-bucket-owner-enforced
