### PR TITLE
[SC-409] Update packer-amazonlinux-docker AMI ID

### DIFF
--- a/templates/ec2/sc-ec2-linux-docker.yaml
+++ b/templates/ec2/sc-ec2-linux-docker.yaml
@@ -23,7 +23,7 @@ Metadata:
 Mappings:
   AMIs:
     AmazonLinuxDocker:
-      AmiId: "ami-0090a06306e93b1e1"  # https://github.com/Sage-Bionetworks-IT/packer-amazonlinux-docker/tree/v1.0.1
+      AmiId: "ami-0b0c7a592286b1ad4"  # https://github.com/Sage-Bionetworks-IT/packer-amazonlinux-docker/tree/v2.0.1
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'


### PR DESCRIPTION
Update the AmazonLinuxDocker base image to one that has a more recent version of Python installed.
