### PR TITLE
IT-3317: Correct volume mounts; update RStudio container to v1.0.1

### DIFF
--- a/templates/ec2/sc-ec2-linux-docker-notebook.yaml
+++ b/templates/ec2/sc-ec2-linux-docker-notebook.yaml
@@ -34,11 +34,13 @@ Mappings:
       ConfigSet: StartContainersJupyter
       DockerImage: quay.io/jupyter/base-notebook:python-3.11
       EC2WorkDir: /home/ssm-user/work
+      NotebookWorkDir: /home/jovyan/work
     Rstudio:
       NoteBookTypeForDocker: rstudio
       ConfigSet: StartContainersRstudio
       DockerImage: ghcr.io/sage-bionetworks-it/rstudio-service-catalog:v1.0.1
       EC2WorkDir: /home/ssm-user/work
+      NotebookWorkDir: /home/rstudio/work
   GlobalVars:
     DockerNetworkName:
       Value: proxy-net
@@ -358,7 +360,8 @@ Resources:
                   'Fn::FindInMap': [NotebookTypeToInitParams, !Ref NotebookType, EC2WorkDir]
                 DOCKER_IMAGE:
                   'Fn::FindInMap': [NotebookTypeToInitParams, !Ref NotebookType, DockerImage]
-                JUPYTER_WORK_DIR: /home/jovyan/work
+                JUPYTER_WORK_DIR:
+                  'Fn::FindInMap': [NotebookTypeToInitParams, !Ref NotebookType, NotebookWorkDir]
                 SERVICE_CATALOG_PREFIX:
                   'Fn::FindInMap': [GlobalVars, SSMParameterPrefix, Value]
                 SSM_PARAMETER_SUFFIX:
@@ -390,7 +393,8 @@ Resources:
                   'Fn::FindInMap': [NotebookTypeToInitParams, !Ref NotebookType, DockerImage]
                 EC2_WORK_DIR:
                   'Fn::FindInMap': [NotebookTypeToInitParams, !Ref NotebookType, EC2WorkDir]
-                RSTUDIO_WORK_DIR: /home/rstudio/work
+                RSTUDIO_WORK_DIR:
+                  'Fn::FindInMap': [NotebookTypeToInitParams, !Ref NotebookType, NotebookWorkDir]
                 SERVICE_CATALOG_PREFIX:
                   'Fn::FindInMap': [GlobalVars, SSMParameterPrefix, Value]
                 SSM_PARAMETER_SUFFIX:

--- a/templates/ec2/sc-ec2-linux-docker-notebook.yaml
+++ b/templates/ec2/sc-ec2-linux-docker-notebook.yaml
@@ -33,12 +33,12 @@ Mappings:
       NoteBookTypeForDocker: jupyter
       ConfigSet: StartContainersJupyter
       DockerImage: quay.io/jupyter/base-notebook:python-3.11
-      EC2WorkDir: /home/ssm-user/workdir
+      EC2WorkDir: /home/ssm-user/work
     Rstudio:
       NoteBookTypeForDocker: rstudio
       ConfigSet: StartContainersRstudio
-      DockerImage: ghcr.io/sage-bionetworks-it/rstudio-service-catalog:v1.0.0
-      EC2WorkDir: /home/ssm-user/workdir
+      DockerImage: ghcr.io/sage-bionetworks-it/rstudio-service-catalog:v1.0.1
+      EC2WorkDir: /home/ssm-user/work
   GlobalVars:
     DockerNetworkName:
       Value: proxy-net
@@ -358,7 +358,7 @@ Resources:
                   'Fn::FindInMap': [NotebookTypeToInitParams, !Ref NotebookType, EC2WorkDir]
                 DOCKER_IMAGE:
                   'Fn::FindInMap': [NotebookTypeToInitParams, !Ref NotebookType, DockerImage]
-                JUPYTER_WORK_DIR: /home/jovyan/workdir
+                JUPYTER_WORK_DIR: /home/jovyan/work
                 SERVICE_CATALOG_PREFIX:
                   'Fn::FindInMap': [GlobalVars, SSMParameterPrefix, Value]
                 SSM_PARAMETER_SUFFIX:
@@ -390,7 +390,7 @@ Resources:
                   'Fn::FindInMap': [NotebookTypeToInitParams, !Ref NotebookType, DockerImage]
                 EC2_WORK_DIR:
                   'Fn::FindInMap': [NotebookTypeToInitParams, !Ref NotebookType, EC2WorkDir]
-                RSTUDIO_WORK_DIR: /home/rstudio
+                RSTUDIO_WORK_DIR: /home/rstudio/work
                 SERVICE_CATALOG_PREFIX:
                   'Fn::FindInMap': [GlobalVars, SSMParameterPrefix, Value]
                 SSM_PARAMETER_SUFFIX:


### PR DESCRIPTION
The previous version had two mistakes in mounting a folder from the parent EC2 into the notebook container:
- The working directory for Jupyter is `/home/jovyan/work` not `/home/jovyan/workdir`.
- In RStudio we mounted the (empty) EC2 folder to `/home/rstudio` which overwrote all the packages, venv, etc. that were intalled in the user homedir. This update simply mounts the host folder into the (otherwise non-existent) `/home/rstudio/work`.

Just for consistency we rename the host folder from `/home/ssm-user/workdir` to `/home/ssm-user/work`.

Depends on https://github.com/Sage-Bionetworks-IT/rstudio-service-catalog/pull/2, which will also have to be tagged with `v1.0.1` for this PR to work.