### PR TITLE
Windows uses x86 types

### DIFF
--- a/templates/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/templates/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -20,12 +20,13 @@ Metadata:
 Parameters:
   WindowsInstanceType:
     AllowedValues:
-      - t3a.small
-      - t3a.medium
-      - t3a.large
-      - t3a.xlarge
-      - t3a.2xlarge
-    Default: t3a.small
+      - t3.nano
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+    Default: t3.small
     Description: Amazon EC2 Instance Type
     Type: String
   VolumeSize:


### PR DESCRIPTION
The windows AMI doesn't seem to work with AMD instance types

This reverts commit 44b30a7988a104e8a834ad1d1abc27ef8001fabc for the windows products only.

