### PR TITLE
[IT-3425] Fix chocolately and JC agent installs

### DIFF
--- a/templates/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/templates/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -147,7 +147,7 @@ Resources:
               source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.8/aws/install-ms-vc.ps1"
               mode: "0664"
             'c:\\scripts\\install-jc-agent.ps1':
-              source: "https://raw.githubusercontent.com/TheJumpCloud/support/v2.10.0/scripts/windows/InstallWindowsAgent.ps1"
+              source: "https://raw.githubusercontent.com/TheJumpCloud/support/master/scripts/windows/InstallWindowsAgent.ps1"
               mode: "0664"
           commands:
             01_install_ms_vc:

--- a/templates/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/templates/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -122,7 +122,7 @@ Resources:
               command: !Join
                 - ''
                 - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
-                  - 'Powershell.exe C:\scripts\install-chocolatey.ps1 > C:\scripts\install-chocolatey.log'
+                  - 'Powershell.exe C:\scripts\install-chocolatey.ps1 -ChocolateyVersion 1.4.0 > C:\scripts\install-chocolatey.log'
             03_install_jq:
               command: 'Powershell.exe C:\ProgramData\chocolatey\bin\choco install jq --yes --no-progress'
             04_install_awscli:
@@ -147,7 +147,7 @@ Resources:
               source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.8/aws/install-ms-vc.ps1"
               mode: "0664"
             'c:\\scripts\\install-jc-agent.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.8/aws/install-jc-agent.ps1"
+              source: "https://raw.githubusercontent.com/TheJumpCloud/support/v2.10.0/scripts/windows/InstallWindowsAgent.ps1"
               mode: "0664"
           commands:
             01_install_ms_vc:
@@ -160,7 +160,7 @@ Resources:
                 - ''
                 - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
                   - 'Powershell.exe C:\scripts\install-jc-agent.ps1 '
-                  - ' -JcConnectKey '
+                  - ' -JumpCloudConnectKey '
                   - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcConnectKey"}}
                   - ' > C:\scripts\install-jc-agent.log'
     Properties:


### PR DESCRIPTION
* chocolately failed to install because the latest version depends on .NET framework 4.8 and requires a reboot after install.  As a quick workaround we are going to pin to an older version of chocolately

* The Jumpcloud agent existing script is outdated because it contains a download url location that is no longer valid. To fix we are updating to use a newer version of the agent install script which is provided by Jumpcloud support[1]

[1] https://github.com/TheJumpCloud/support/tree/master
