### PR TITLE
[IT-3369] Upgrade set_env_vars_file.ps1 to use IMDSv2

### DIFF
--- a/templates/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/templates/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -132,7 +132,7 @@ Resources:
         set_env_vars:
           files:
             'c:\\scripts\\set_env_vars_file.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.8/aws/set_env_vars_file.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.9/aws/set_env_vars_file.ps1"
               mode: "0664"
           commands:
             01_set_env_vars:


### PR DESCRIPTION
IMDSv1 can be disabled by the AMI, upgrade to IMDSv2 everywhere.