### PR TITLE
[IT-3456] Test Windows OS upgrade

### DIFF
--- a/templates/ec2/sc-ec2-windows-jumpcloud-test.yaml
+++ b/templates/ec2/sc-ec2-windows-jumpcloud-test.yaml
@@ -1,0 +1,241 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Service Catalog: Windows EC2 with Jumpcloud integration.'
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E7001
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Windows Instance Configuration
+        Parameters:
+          - WindowsInstanceType
+          - VolumeSize
+    ParameterLabels:
+      WindowsInstanceType:
+        default: Instance Type
+      VolumeSize:
+        default: Disk Size
+Parameters:
+  WindowsInstanceType:
+    AllowedValues:
+      - t3a.small
+      - t3a.medium
+      - t3a.large
+      - t3a.xlarge
+      - t3a.2xlarge
+    Default: t3a.small
+    Description: Amazon EC2 Instance Type
+    Type: String
+  VolumeSize:
+    Description: The EC2 volume size (in GB)
+    Type: Number
+    Default: 30
+    MinValue: 10
+    MaxValue: 2000
+Mappings:
+  AccountToImportParams:
+    'Fn::Transform':
+      Name: 'AWS::Include'
+      Parameters:
+        # include is @ https://github.com/Sage-Bionetworks/admincentral-infra/blob/master/templates/cfn-service-catalog-snippets.yaml
+        Location: s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipool-sc-lib-infra/ScAccountToExportMappping.yaml
+Resources:
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      ManagedPolicyArns:
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
+        - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore' #For maintenance tasks
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+                - ssm.amazonaws.com #For maintenance service
+            Action:
+              - sts:AssumeRole
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+        - !Ref 'InstanceRole'
+  WindowsInstance:
+    Type: AWS::EC2::Instance
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W1011
+            - E1022
+      'AWS::CloudFormation::Init':
+        configSets:
+          SetupCfn:
+            - cfn_hup_service
+          SetupApps:
+            - install_apps
+          SetEnv:
+            - set_env_vars
+          SetupJumpcloud:
+            - install_jc
+        # Cfn-hup setting, it is to monitor the change of metadata.
+        # When there is change in the contents of json file in the metadata section, cfn-hup will call cfn-init.
+        cfn_hup_service:
+          files:
+             "c:\\cfn\\cfn-hup.conf":
+               content: !Sub |
+                 [main]
+                 stack=${AWS::StackId}
+                 region=${AWS::Region}
+                 interval=1
+             "c:\\cfn\\hooks.d\\cfn-auto-reloader.conf":
+               content: !Sub |
+                 [cfn-auto-reloader-hook]
+                 triggers=post.update
+                 path=Resources.WindowsInstance.Metadata.AWS::CloudFormation::Init
+                 action=cfn-init.exe -v --stack ${AWS::StackId} --resource WindowsInstance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetEnv,SetupJumpcloud
+          services:
+            windows:
+              cfn-hup:
+                enabled: 'true'
+                ensureRunning: 'true'
+                files:
+                  - "c:\\cfn\\cfn-hup.conf"
+                  - "c:\\cfn\\hooks.d\\cfn-auto-reloader.conf"
+        install_apps:
+          files:
+            'c:\\scripts\\install-chocolatey.ps1':
+              source: "https://chocolatey.org/install.ps1"
+              mode: "0664"
+          commands:
+            01_install_nuget:
+              command: 'Powershell.exe Install-PackageProvider -Name NuGet -Force'
+            02_install_chocolatey:
+              command: !Join
+                - ''
+                - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
+                  - 'Powershell.exe C:\scripts\install-chocolatey.ps1 > C:\scripts\install-chocolatey.log'
+            03_install_jq:
+              command: 'Powershell.exe C:\ProgramData\chocolatey\bin\choco install jq --yes --no-progress'
+            04_install_awscli:
+              command: 'Powershell.exe C:\ProgramData\chocolatey\bin\choco install awscli --yes --no-progress --ignore-checksums'
+            05_install_googlechrome:
+              command: 'Powershell.exe C:\ProgramData\chocolatey\bin\choco install googlechrome --yes --no-progress --ignore-checksums'
+        set_env_vars:
+          files:
+            'c:\\scripts\\set_env_vars_file.ps1':
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.9/aws/set_env_vars_file.ps1"
+              mode: "0664"
+          commands:
+            01_set_env_vars:
+              command: !Join
+                - ''
+                - - 'Powershell.exe C:\scripts\set_env_vars_file.ps1 '
+                  - '-StackId '
+                  - !Ref AWS::StackId
+        install_jc:
+          files:
+            'c:\scripts\install-ms-vc.ps1':
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.8/aws/install-ms-vc.ps1"
+              mode: "0664"
+            'c:\\scripts\\install-jc-agent.ps1':
+              source: "https://raw.githubusercontent.com/TheJumpCloud/support/master/scripts/windows/InstallWindowsAgent.ps1"
+              mode: "0664"
+          commands:
+            01_install_ms_vc:
+              command: !Join
+                - ''
+                - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
+                  - 'Powershell.exe C:\scripts\install-ms-vc.ps1 > C:\scripts\install-ms-vc.log'
+            02_install_jc_agent:
+              command: !Join
+                - ''
+                - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
+                  - 'Powershell.exe C:\scripts\install-jc-agent.ps1 '
+                  - ' -JumpCloudConnectKey '
+                  - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcConnectKey"}}
+                  - ' > C:\scripts\install-jc-agent.log'
+    Properties:
+      ImageId: 'ami-08079232459aa7414'    # https://github.com/Sage-Bionetworks-IT/packer-winserver-2022/releases/tag/v0.0.1
+      InstanceType: !Ref 'WindowsInstanceType'
+      SubnetId: !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", PrivateSubnet1]
+      SecurityGroupIds:
+        - !ImportValue
+          'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VpnSecurityGroup]
+        - !Ref TgwHubSecurityGroup
+      KeyName: 'scipool'
+      IamInstanceProfile: !Ref 'InstanceProfile'
+      BlockDeviceMappings:
+        -
+          DeviceName: "/dev/sda1"
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: !Ref VolumeSize
+            Encrypted: true
+      UserData:
+        Fn::Base64: !Sub |
+          <script>
+          cfn-init.exe -v --stack ${AWS::StackId} --resource WindowsInstance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetEnv,SetupJumpcloud
+          cfn-signal.exe -e %errorlevel% --stack ${AWS::StackId} --resource WindowsInstance --region ${AWS::Region}
+          </script>
+      PropagateTagsToVolumeOnCreation: true
+      Tags:
+        - Key: Name
+          Value: !Ref 'AWS::StackName'
+        - Key: Description
+          Value: !Sub "Service Catalog instance created by ${AWS::StackName}"
+        - Key: "ManagedInstanceMaintenanceTarget"
+          Value: "yes"
+        - Key: "PatchGroup"
+          Value: "prod-default"
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT30M
+  TagInstance:
+    DependsOn: "InstanceProfile"
+    Type: Custom::SynapseTagger
+    Properties:
+      ServiceToken: !ImportValue
+        'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetInstanceTagsFunctionArn'
+      InstanceId: !Ref WindowsInstance
+  TgwHubSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W1011
+    Properties:
+      GroupDescription: 'Allow network access from TGW Hub'
+      VpcId: !ImportValue
+        'Fn::FindInMap': [AccountToImportParams, !Ref "AWS::AccountId", VPCId]
+      SecurityGroupIngress:
+        - CidrIp: "10.50.0.0/16"
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+Outputs:
+  WindowsInstancePrivateIpAddress:
+    Description: 'The IP Address of the EC2 instance'
+    Value: !GetAtt 'WindowsInstance.PrivateIp'
+  WindowsInstanceId:
+    Description: 'The ID of the EC2 instance'
+    Value: !Ref 'WindowsInstance'
+  WindowsInstanceType:
+    Description: 'The EC2 instance type'
+    Value: !Ref 'WindowsInstanceType'
+  EC2ConsoleURI:
+    Description: 'Check your instance status with this link to the AWS Console'
+    Value: !Sub "https://console.aws.amazon.com/ec2/v2/home?region=${AWS::Region}#Instances:search=${WindowsInstance}"
+  Documentation:
+    Description: 'Service Catalog Documentation'
+    Value: "https://help.sc.sageit.org/sc/Service-Catalog-Provisioning.938836322.html"


### PR DESCRIPTION
Test upgrading from Windows Server 2019 to Windows Server 2022 by creating a new template. This new template will be used to create a new SC product in sc-dev.sageit.org. Once the new product has been validated, these template changes can be ported over to the current SC product, and the test template removed.
