### PR TITLE
[IT-3420] remove nano instance type

### DIFF
--- a/templates/ec2/sc-ec2-linux-docker-notebook.yaml
+++ b/templates/ec2/sc-ec2-linux-docker-notebook.yaml
@@ -55,7 +55,6 @@ Parameters:
 
   EC2InstanceType:
     AllowedValues:
-      - t3a.nano
       - t3a.micro
       - t3a.small
       - t3a.medium

--- a/templates/ec2/sc-ec2-linux-docker.yaml
+++ b/templates/ec2/sc-ec2-linux-docker.yaml
@@ -33,7 +33,6 @@ Mappings:
 Parameters:
   EC2InstanceType:
     AllowedValues:
-      - t3a.nano
       - t3a.micro
       - t3a.small
       - t3a.medium


### PR DESCRIPTION
The nano instance type is not adequate for our service catalog instances so lets remove them.  Users still have lots of options to use other instances types.

