### PR TITLE
[IT-3547] Use latest amazonlinux version

### DIFF
--- a/templates/ec2/sc-ec2-linux-docker.yaml
+++ b/templates/ec2/sc-ec2-linux-docker.yaml
@@ -23,7 +23,7 @@ Metadata:
 Mappings:
   AMIs:
     AmazonLinuxDocker:
-      AmiId: "ami-0199f2d4739bba0b6"  # https://github.com/Sage-Bionetworks-IT/packer-amazonlinux-docker/tree/master
+      AmiId: "ami-021590301011f74b3"  # https://github.com/Sage-Bionetworks-IT/packer-amazonlinux-docker/tree/v2.0.2
   AccountToImportParams:
     'Fn::Transform':
       Name: 'AWS::Include'


### PR DESCRIPTION
A new amazonlinux image was built in April, but this template was not updated. Use the latest version of the image.
