### PR TITLE
IT-3421:  Refer to containers by Major.minor tags; run Watchtower

### DIFF
--- a/templates/ec2/sc-ec2-linux-docker-notebook.yaml
+++ b/templates/ec2/sc-ec2-linux-docker-notebook.yaml
@@ -38,7 +38,7 @@ Mappings:
     Rstudio:
       NoteBookTypeForDocker: rstudio
       ConfigSet: StartContainersRstudio
-      DockerImage: ghcr.io/sage-bionetworks-it/rstudio-service-catalog:v1.0.1
+      DockerImage: ghcr.io/sage-bionetworks-it/rstudio-service-catalog:1.0
       EC2WorkDir: /home/ssm-user/work
       NotebookWorkDir: /home/rstudio/work
   GlobalVars:
@@ -264,12 +264,14 @@ Resources:
             - start_reverse_proxy
             - make_work_dir
             - start_jupyter_notebook
+            - start_watchtower
           StartContainersRstudio:
             - set_env_vars
             - start_docker_network
             - start_reverse_proxy
             - make_work_dir
             - start_rstudio_notebook
+            - start_watchtower
         set_env_vars:
           files:
             /opt/sage/bin/make_env_vars_file.sh:
@@ -310,7 +312,7 @@ Resources:
                 -e AWS_REGION=${AWS_REGION} \
                 -e SERVICE_CATALOG_PREFIX=${SERVICE_CATALOG_PREFIX} \
                 -e SSM_PARAMETER_SUFFIX=${SSM_PARAMETER_SUFFIX} \
-                ghcr.io/sage-bionetworks-it/notebook-reverse-proxy-${NOTEBOOK_TYPE}:v1.0.1
+                ghcr.io/sage-bionetworks-it/notebook-reverse-proxy-${NOTEBOOK_TYPE}:1.0
               env:
                 AWS_REGION: !Ref AWS::Region
                 NETWORK_NAME:
@@ -400,6 +402,17 @@ Resources:
                   'Fn::FindInMap': [GlobalVars, SSMParameterSuffix, Value]
                 AWS_REGION:
                   'Fn::Sub': ${AWS::Region}
+        start_watchtower:
+          commands:
+            start_watchtower:
+              command: |
+                # For idempotency this command tries to restart an existing container and only creates one if that fails.
+                docker start watchtower || \
+                docker run -d \
+                --name watchtower \
+                --restart unless-stopped \
+                -v /var/run/docker.sock:/var/run/docker.sock \
+                containrrr/watchtower
     Properties:
       ImageId: "ami-04e92928ecf1c2066" # https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-jammy/tree/v1.0.2
       InstanceType: !Ref 'EC2InstanceType'


### PR DESCRIPTION
IT-3421:  

Refer to notebook container and reverse proxy by Major.minor tag (1.0) instead of Major.minor.patch tag (1.0.1); This will applying security updates to containers by pushing a new 'patch' version.

Run Watchtower on notebook EC2.  This will perform a daily check for a new version of each container with the given Major.minor patch and replace the existing container with the new one.  (Note that `IT` should be judicious in pushing patches and should notify users in advance of the interruption.)
