### PR TITLE
[IT-4074] Enable access flags for S3 buckets

### DIFF
--- a/templates/s3/sc-s3-encrypted-ra.yaml
+++ b/templates/s3/sc-s3-encrypted-ra.yaml
@@ -37,6 +37,11 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/templates/s3/sc-s3-synapse-ra.yaml
+++ b/templates/s3/sc-s3-synapse-ra.yaml
@@ -47,6 +47,11 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:


### PR DESCRIPTION
Security hub says we should enable per bucket access flags when creating buckets to make sure they are private.

