### PR TITLE
IT-4369: Pre-install the policy for SSM patching

### DIFF
--- a/templates/ec2/sc-ec2-linux-docker.yaml
+++ b/templates/ec2/sc-ec2-linux-docker.yaml
@@ -102,6 +102,7 @@ Resources:
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-get-role-policy-ReadAssumedRoleInformationPolicy'
         - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+        - "arn:aws:iam::aws:policy/AWSQuickSetupPatchPolicyBaselineAccess" #For SSM patching
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/ec2/sc-ec2-linux-jumpcloud-notebook.yaml
@@ -92,6 +92,7 @@ Resources:
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-get-role-policy-ReadAssumedRoleInformationPolicy'
         - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore' #For maintenance tasks
+        - 'arn:aws:iam::aws:policy/AWSQuickSetupPatchPolicyBaselineAccess' #For SSM patching
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-sc-product-ec2-linux-notebook-write-to-ssm-policy-WriteToSSMPolicy'
       AssumeRolePolicyDocument:

--- a/templates/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/templates/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -52,6 +52,7 @@ Resources:
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
         - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore' #For maintenance tasks
+        - 'arn:aws:iam::aws:policy/AWSQuickSetupPatchPolicyBaselineAccess' #For SSM patching
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
This PR adds the AWS-manged policy 'AWSQuickSetupPatchPolicyBaselineAccess' the the instance profiles
so that it's under control of Cloudformation and can be detached from the role when an instance is terminated.

NB: Hopefully adding is OK and will be a no-op since the policy has already been added manually.
