### PR TITLE
SYNR-1544: update notebook product from rstudio-service-catalog:1.1 to 1.2

### DIFF
--- a/templates/ec2/sc-ec2-linux-docker-notebook.yaml
+++ b/templates/ec2/sc-ec2-linux-docker-notebook.yaml
@@ -38,7 +38,7 @@ Mappings:
     Rstudio:
       NoteBookTypeForDocker: rstudio
       ConfigSet: StartContainersRstudio
-      DockerImage: ghcr.io/sage-bionetworks-it/rstudio-service-catalog:1.1
+      DockerImage: ghcr.io/sage-bionetworks-it/rstudio-service-catalog:1.2
       WorkVolumeName: work-dir
       NotebookWorkDir: /home/rstudio
   GlobalVars:


### PR DESCRIPTION
 update notebook product from rstudio-service-catalog:1.1 to 1.2

Depends on Sage-Bionetworks-IT/rstudio-service-catalog#14
and then tagging with version 1.2.0